### PR TITLE
fix: Make discovery import report per-site failures so onboarding does not fail silently

### DIFF
--- a/.tamtam/agents/issue-cruncher.md
+++ b/.tamtam/agents/issue-cruncher.md
@@ -1,0 +1,7 @@
+---
+model: normal
+skillIds: ["agent-issue-cruncher"]
+prerequisiteCommand: "curl -fsS \"http://localhost:1337/api/projects/by-project/seo-tools/issues?trusted_only=1\""
+---
+
+

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { applyImportResults, buildImportSummary, getImportResult, type DiscoverySite, type ImportResult, type ImportSummary } from '@/lib/discovery-import';
 
 interface Site {
   id: string;
@@ -41,8 +42,9 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
   const [form, setForm] = useState<Site>({ id: '', ...EMPTY_SITE });
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [discovering, setDiscovering] = useState(false);
-  const [discovered, setDiscovered] = useState<Site[] | null>(null);
+  const [discovered, setDiscovered] = useState<DiscoverySite<Site>[] | null>(null);
   const [discoverError, setDiscoverError] = useState('');
+  const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -119,6 +121,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
   async function handleDiscover() {
     setDiscovering(true);
     setDiscoverError('');
+    setImportSummary(null);
     setDiscovered(null);
     setSelected(new Set());
     try {
@@ -157,18 +160,40 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
   async function handleImport() {
     if (!discovered) return;
     setImporting(true);
+    setDiscoverError('');
+    setImportSummary(null);
     const toImport = discovered.filter(s => selected.has(s.id));
     try {
-      await Promise.all(toImport.map(site =>
-        fetch('/api/sites', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(site),
-        })
-      ));
-      await reloadSites();
-      setDiscovered(null);
-      setSelected(new Set());
+      const results = await Promise.all(toImport.map(async (site): Promise<ImportResult> => {
+        try {
+          const { importError: _importError, ...siteToSave } = site;
+          const res = await fetch('/api/sites', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(siteToSave),
+          });
+          return {
+            id: site.id,
+            ...(await getImportResult(res)),
+          };
+        } catch {
+          return {
+            id: site.id,
+            ok: false,
+            error: 'Request failed',
+          };
+        }
+      }));
+
+      const nextState = applyImportResults(discovered, selected, results);
+      setDiscovered(nextState.remaining);
+      setSelected(nextState.selected);
+
+      if (nextState.successCount > 0) {
+        await reloadSites();
+      }
+
+      setImportSummary(buildImportSummary(nextState.successCount, nextState.failureCount));
     } catch {
       setDiscoverError('Import failed');
     } finally {
@@ -413,6 +438,11 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
           </div>
 
           {discoverError && <p className="text-sm text-red-400">{discoverError}</p>}
+          {importSummary && (
+            <p className={`text-sm ${importSummary.tone === 'warning' ? 'text-amber-300' : 'text-emerald-300'}`}>
+              {importSummary.message}
+            </p>
+          )}
 
           {discovered !== null && (
             discovered.length === 0 ? (
@@ -430,18 +460,23 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                 </div>
                 <div className="space-y-2">
                   {discovered.map(site => (
-                    <label key={site.id} className="flex items-center gap-3 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={selected.has(site.id)}
-                        onChange={() => toggleSelect(site.id)}
-                        className="rounded border-neutral-600"
-                      />
-                      <span className="text-sm text-white">{site.domain}</span>
-                      {site.ga4PropertyId && (
-                        <span className="text-xs text-neutral-500">GA4: {site.ga4PropertyId}</span>
+                    <div key={site.id} className="space-y-1">
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(site.id)}
+                          onChange={() => toggleSelect(site.id)}
+                          className="rounded border-neutral-600"
+                        />
+                        <span className="text-sm text-white">{site.domain}</span>
+                        {site.ga4PropertyId && (
+                          <span className="text-xs text-neutral-500">GA4: {site.ga4PropertyId}</span>
+                        )}
+                      </label>
+                      {site.importError && (
+                        <p className="pl-6 text-xs text-red-400">{site.importError}</p>
                       )}
-                    </label>
+                    </div>
                   ))}
                 </div>
                 <button

--- a/src/lib/__tests__/discovery-import.test.ts
+++ b/src/lib/__tests__/discovery-import.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyImportResults, buildImportSummary, getImportResult, type DiscoverySite, type ImportResult } from '../discovery-import';
+
+type Site = {
+  id: string;
+  domain: string;
+};
+
+describe('getImportResult', () => {
+  it('treats a response as success only when HTTP is ok and payload ok is true', async () => {
+    const res = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getImportResult(res)).resolves.toEqual({ ok: true });
+  });
+
+  it('returns a failure when HTTP is ok but payload ok is false', async () => {
+    const res = new Response(JSON.stringify({ ok: false, error: 'Duplicate site' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getImportResult(res)).resolves.toEqual({
+      ok: false,
+      error: 'Duplicate site',
+    });
+  });
+
+  it('returns a failure when HTTP status is not ok', async () => {
+    const res = new Response(JSON.stringify({ error: 'Validation failed' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getImportResult(res)).resolves.toEqual({
+      ok: false,
+      error: 'Validation failed',
+    });
+  });
+});
+
+describe('applyImportResults', () => {
+  it('keeps failed rows visible and removes successful imports', () => {
+    const discovered: DiscoverySite<Site>[] = [
+      { id: 'a', domain: 'a.test' },
+      { id: 'b', domain: 'b.test' },
+      { id: 'c', domain: 'c.test' },
+    ];
+    const selected = new Set(['a', 'b']);
+    const results: ImportResult[] = [
+      { id: 'a', ok: true },
+      { id: 'b', ok: false, error: 'Duplicate domain' },
+    ];
+
+    const nextState = applyImportResults(discovered, selected, results);
+
+    expect(nextState.remaining).toEqual([
+      { id: 'b', domain: 'b.test', importError: 'Duplicate domain' },
+      { id: 'c', domain: 'c.test' },
+    ]);
+    expect([...nextState.selected]).toEqual(['b']);
+    expect(nextState.successCount).toBe(1);
+    expect(nextState.failureCount).toBe(1);
+  });
+
+  it('builds a success summary for a later successful batch even when an older failed row remains', () => {
+    const discoveredAfterFirstBatch: DiscoverySite<Site>[] = [
+      { id: 'b', domain: 'b.test', importError: 'Duplicate domain' },
+      { id: 'c', domain: 'c.test' },
+    ];
+    const selected = new Set(['c']);
+    const results: ImportResult[] = [{ id: 'c', ok: true }];
+
+    const nextState = applyImportResults(discoveredAfterFirstBatch, selected, results);
+    const summary = buildImportSummary(nextState.successCount, nextState.failureCount);
+
+    expect(nextState.remaining).toEqual([
+      { id: 'b', domain: 'b.test', importError: 'Duplicate domain' },
+    ]);
+    expect(summary).toEqual({
+      message: 'Imported 1 site.',
+      tone: 'success',
+    });
+  });
+});
+
+describe('buildImportSummary', () => {
+  it('returns a warning summary for partial failure', () => {
+    expect(buildImportSummary(2, 1)).toEqual({
+      message: 'Imported 2 sites. 1 failed.',
+      tone: 'warning',
+    });
+  });
+
+  it('returns null when nothing was imported', () => {
+    expect(buildImportSummary(0, 0)).toBeNull();
+  });
+});

--- a/src/lib/discovery-import.ts
+++ b/src/lib/discovery-import.ts
@@ -1,0 +1,102 @@
+type WithId = {
+  id: string;
+};
+
+export type DiscoverySite<T extends WithId> = T & {
+  importError?: string;
+};
+
+export type ImportResult = {
+  id: string;
+  ok: boolean;
+  error?: string;
+};
+
+export type ImportSummary = {
+  message: string;
+  tone: 'success' | 'warning';
+};
+
+type ImportPayload = {
+  ok?: boolean;
+  error?: string;
+};
+
+export async function getImportResult(response: Response): Promise<Omit<ImportResult, 'id'>> {
+  let payload: ImportPayload | null = null;
+
+  try {
+    payload = await response.json() as ImportPayload;
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: payload?.error?.trim() || `Request failed (${response.status})`,
+    };
+  }
+
+  if (payload?.ok === true) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    error: payload?.error?.trim() || 'Save failed',
+  };
+}
+
+export function applyImportResults<T extends WithId>(
+  discovered: DiscoverySite<T>[],
+  selectedIds: Set<string>,
+  results: ImportResult[],
+) {
+  const resultsById = new Map(results.map(result => [result.id, result]));
+  const remaining: DiscoverySite<T>[] = [];
+
+  for (const site of discovered) {
+    if (!selectedIds.has(site.id)) {
+      remaining.push(site);
+      continue;
+    }
+
+    const result = resultsById.get(site.id);
+    if (result?.ok) {
+      continue;
+    }
+
+    remaining.push({
+      ...site,
+      importError: result?.error || 'Import failed',
+    });
+  }
+
+  return {
+    remaining,
+    selected: new Set(remaining.filter(site => selectedIds.has(site.id)).map(site => site.id)),
+    successCount: results.filter(result => result.ok).length,
+    failureCount: results.filter(result => !result.ok).length,
+  };
+}
+
+export function buildImportSummary(successCount: number, failureCount: number): ImportSummary | null {
+  if (failureCount > 0) {
+    return {
+      message: successCount > 0
+        ? `Imported ${successCount} site${successCount !== 1 ? 's' : ''}. ${failureCount} failed.`
+        : `${failureCount} site${failureCount !== 1 ? 's' : ''} failed to import.`,
+      tone: 'warning',
+    };
+  }
+
+  if (successCount > 0) {
+    return {
+      message: `Imported ${successCount} site${successCount !== 1 ? 's' : ''}.`,
+      tone: 'success',
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes #53

Implemented via TamTam from issue [#53](https://github.com/3h4x/seo-tools/issues/53).