### PR TITLE
fix: Invalidate cached audit and analytics data when a managed site is edited

### DIFF
--- a/.tamtam/agents/issue-cruncher.md
+++ b/.tamtam/agents/issue-cruncher.md
@@ -1,5 +1,6 @@
 ---
 model: normal
+schedule: 30m
 skillIds: ["agent-issue-cruncher"]
 prerequisiteCommand: "curl -fsS \"http://localhost:1337/api/projects/by-project/seo-tools/issues?trusted_only=1\""
 ---

--- a/app/api/sites/route.ts
+++ b/app/api/sites/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '@/lib/db';
+import { invalidateManagedSiteCache } from '@/lib/site-cache';
 import type { Site } from '@/lib/sites';
 
 export async function GET() {
@@ -15,7 +16,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'id, name, and domain are required' }, { status: 400 });
   }
 
+  const previousSite = dbGetSites().find((managedSite) => managedSite.id === site.id) ?? null;
   dbUpsertSite(site, sortOrder);
+  invalidateManagedSiteCache(previousSite, site);
   return NextResponse.json({ ok: true });
 }
 
@@ -24,6 +27,10 @@ export async function DELETE(req: NextRequest) {
   if (!id) {
     return NextResponse.json({ ok: false, error: 'id query param required' }, { status: 400 });
   }
+  const previousSite = dbGetSites().find((managedSite) => managedSite.id === id) ?? null;
   dbDeleteSite(id);
+  if (previousSite) {
+    invalidateManagedSiteCache(previousSite, null);
+  }
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -6,7 +6,12 @@ vi.mock('../db', () => ({
   dbDeleteSite: vi.fn(),
 }));
 
+vi.mock('../site-cache', () => ({
+  invalidateManagedSiteCache: vi.fn(),
+}));
+
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '../db';
+import { invalidateManagedSiteCache } from '../site-cache';
 import { GET, POST, DELETE } from '../../../app/api/sites/route';
 import { NextRequest } from 'next/server';
 
@@ -24,6 +29,7 @@ function deleteReq(id: string): NextRequest {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(dbGetSites).mockReturnValue([] as never);
 });
 
 describe('GET /api/sites', () => {
@@ -52,6 +58,7 @@ describe('POST /api/sites', () => {
     const data = await res.json();
     expect(data).toEqual({ ok: true });
     expect(dbUpsertSite).toHaveBeenCalledWith(site, undefined);
+    expect(invalidateManagedSiteCache).toHaveBeenCalledWith(null, site);
   });
 
   it('passes sortOrder to dbUpsertSite when provided', async () => {
@@ -63,12 +70,41 @@ describe('POST /api/sites', () => {
     );
   });
 
+  it('invalidates cache with both old and new identities when updating a site', async () => {
+    const existingSite = {
+      id: 'site1',
+      name: 'Site 1',
+      domain: 'old.example.com',
+      scUrl: 'sc-domain:old.example.com',
+      ga4PropertyId: '1234',
+      testPages: ['/'],
+      skipChecks: ['ogImage'],
+    };
+    const updatedSite = {
+      id: 'site1',
+      name: 'Site 1',
+      domain: 'new.example.com',
+      scUrl: 'sc-domain:new.example.com',
+      ga4PropertyId: '5678',
+      testPages: ['/landing'],
+      skipChecks: ['internalLinks'],
+    };
+    vi.mocked(dbGetSites).mockReturnValue([existingSite] as never);
+
+    const res = await POST(postReq(updatedSite));
+
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalledWith(updatedSite, undefined);
+    expect(invalidateManagedSiteCache).toHaveBeenCalledWith(existingSite, updatedSite);
+  });
+
   it('returns 400 when id is missing', async () => {
     const res = await POST(postReq({ name: 'Site', domain: 'site.com' }));
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
     expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when name is missing', async () => {
@@ -76,6 +112,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when domain is missing', async () => {
@@ -83,15 +120,20 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 });
 
 describe('DELETE /api/sites', () => {
   it('deletes site by id and returns { ok: true }', async () => {
+    const existingSite = { id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: [] };
+    vi.mocked(dbGetSites).mockReturnValue([existingSite] as never);
+
     const res = await DELETE(deleteReq('site1'));
     const data = await res.json();
     expect(data).toEqual({ ok: true });
     expect(dbDeleteSite).toHaveBeenCalledWith('site1');
+    expect(invalidateManagedSiteCache).toHaveBeenCalledWith(existingSite, null);
   });
 
   it('returns 400 when id query param is missing', async () => {
@@ -101,6 +143,7 @@ describe('DELETE /api/sites', () => {
     const data = await res.json();
     expect(data.ok).toBe(false);
     expect(dbDeleteSite).not.toHaveBeenCalled();
+    expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when id query param is empty', async () => {
@@ -109,5 +152,6 @@ describe('DELETE /api/sites', () => {
     const data = await res.json();
     expect(data.ok).toBe(false);
     expect(dbDeleteSite).not.toHaveBeenCalled();
+    expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -16,6 +16,9 @@ import {
   getCached,
   setCache,
   clearCache,
+  clearCacheEntry,
+  clearCacheEntriesByPrefix,
+  clearSitemapSyncState,
   upsertScDaily,
   upsertGa4Daily,
   getDb,
@@ -27,7 +30,7 @@ import {
 /** Wipe volatile tables between tests so state never leaks. */
 function resetDb() {
   const db = getDb();
-  db.exec('DELETE FROM api_cache; DELETE FROM sc_daily; DELETE FROM ga4_daily; DELETE FROM config;');
+  db.exec('DELETE FROM api_cache; DELETE FROM sitemap_state; DELETE FROM sc_daily; DELETE FROM ga4_daily; DELETE FROM config;');
 }
 
 beforeEach(resetDb);
@@ -124,6 +127,47 @@ describe('clearCache', () => {
 
   it('is idempotent — calling twice does not throw', () => {
     expect(() => { clearCache(); clearCache(); }).not.toThrow();
+  });
+});
+
+describe('targeted cache clearing', () => {
+  it('removes one exact cache entry', () => {
+    setCache('audit', 'site-a', { a: 1 });
+    setCache('audit', 'site-b', { b: 2 });
+
+    clearCacheEntry('audit', 'site-a');
+
+    expect(getCached('audit', 'site-a')).toBeNull();
+    expect(getCached('audit', 'site-b')).toEqual({ b: 2 });
+  });
+
+  it('removes cache entries by key prefix for one site', () => {
+    setCache('sc-data-7', 'sc-domain:example.com', { clicks: 1 });
+    setCache('sc-pages-7', 'sc-domain:example.com', { pages: [] });
+    setCache('sc-data-7', 'sc-domain:other.com', { clicks: 2 });
+
+    clearCacheEntriesByPrefix('sc-', 'sc-domain:example.com');
+
+    expect(getCached('sc-data-7', 'sc-domain:example.com')).toBeNull();
+    expect(getCached('sc-pages-7', 'sc-domain:example.com')).toBeNull();
+    expect(getCached('sc-data-7', 'sc-domain:other.com')).toEqual({ clicks: 2 });
+  });
+
+  it('removes only the requested sitemap sync state row', () => {
+    const db = getDb();
+    const insertState = db.prepare(`
+      INSERT INTO sitemap_state (
+        site_id, sitemap_url, content_hash, url_count, latest_lastmod,
+        last_submitted_at, last_checked_at, submit_count
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insertState.run('site-a', 'https://a.example/sitemap.xml', 'same-hash', 1, null, 100, 100, 1);
+    insertState.run('site-b', 'https://b.example/sitemap.xml', 'same-hash', 1, null, 100, 100, 1);
+
+    clearSitemapSyncState('site-a');
+
+    expect(db.prepare('SELECT site_id FROM sitemap_state WHERE site_id = ?').get('site-a')).toBeUndefined();
+    expect(db.prepare('SELECT site_id FROM sitemap_state WHERE site_id = ?').get('site-b')).toEqual({ site_id: 'site-b' });
   });
 });
 

--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  clearCacheEntry: vi.fn(),
+  clearCacheEntriesByPrefix: vi.fn(),
+  clearSitemapSyncState: vi.fn(),
+}));
+
+import { clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from '../db';
+import { invalidateManagedSiteCache } from '../site-cache';
+import type { Site } from '../sites';
+
+function makeSite(overrides: Partial<Site> = {}): Site {
+  return {
+    id: 'site1',
+    name: 'Site 1',
+    domain: 'example.com',
+    testPages: ['/'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('invalidateManagedSiteCache', () => {
+  it('clears all cache families for a new managed site identity', () => {
+    const site = makeSite({ ga4PropertyId: '1234' });
+
+    invalidateManagedSiteCache(null, site);
+
+    expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
+    expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
+    expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-data-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-queries-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-pages-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
+  });
+
+  it('clears Search Console and GA4 caches for previous and next identities when updating', () => {
+    const previous = makeSite({
+      domain: 'old.example.com',
+      scUrl: 'sc-domain:old.example.com',
+      ga4PropertyId: '1234',
+    });
+    const next = makeSite({
+      domain: 'new.example.com',
+      scUrl: 'sc-domain:new.example.com',
+      ga4PropertyId: '5678',
+    });
+
+    invalidateManagedSiteCache(previous, next);
+
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:old.example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '5678');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '5678');
+    expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
+  });
+
+  it('clears sitemap sync state when the Search Console identity changes but the domain stays the same', () => {
+    const previous = makeSite({
+      scUrl: 'https://example.com/',
+      ga4PropertyId: '1234',
+    });
+    const next = makeSite({
+      scUrl: 'sc-domain:example.com',
+      ga4PropertyId: '1234',
+    });
+
+    invalidateManagedSiteCache(previous, next);
+
+    expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
+  });
+
+  it('does not clear sitemap sync state for non-sitemap identity changes', () => {
+    const previous = makeSite({ name: 'Old Name', ga4PropertyId: '1234' });
+    const next = makeSite({ name: 'New Name', ga4PropertyId: '5678' });
+
+    invalidateManagedSiteCache(previous, next);
+
+    expect(clearSitemapSyncState).not.toHaveBeenCalled();
+  });
+
+  it('clears sitemap sync state when deleting a managed site', () => {
+    const previous = makeSite({ ga4PropertyId: '1234' });
+
+    invalidateManagedSiteCache(previous, null);
+
+    expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
+  });
+
+  it('does not clear duplicate identities twice', () => {
+    const previous = makeSite({ ga4PropertyId: '1234' });
+    const next = makeSite({ ga4PropertyId: '1234' });
+
+    invalidateManagedSiteCache(previous, next);
+
+    expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
+    expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
+    expect(clearCacheEntry).toHaveBeenCalledTimes(2);
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(6);
+    expect(clearSitemapSyncState).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -222,6 +222,33 @@ export function clearCache(keyPattern?: string): void {
   }
 }
 
+export function clearCacheEntry(cacheKey: string, siteId: string): void {
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM api_cache WHERE cache_key = ? AND site_id = ?').run(cacheKey, siteId);
+  } catch {
+    // silently fail
+  }
+}
+
+export function clearCacheEntriesByPrefix(cacheKeyPrefix: string, siteId: string): void {
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM api_cache WHERE cache_key LIKE ? AND site_id = ?').run(`${cacheKeyPrefix}%`, siteId);
+  } catch {
+    // silently fail
+  }
+}
+
+export function clearSitemapSyncState(siteId: string): void {
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM sitemap_state WHERE site_id = ?').run(siteId);
+  } catch {
+    // silently fail
+  }
+}
+
 // --- Query helpers ---
 
 interface ScTrendPoint {

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -1,0 +1,67 @@
+import { clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from './db';
+import { getSCUrl, type Site } from './sites';
+
+const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-'] as const;
+const GA4_PROPERTY_CACHE_PREFIXES = ['ga4-', 'rum-cwv-'] as const;
+
+function getCacheIdentities(site: Site): {
+  auditSiteId: string;
+  domain: string;
+  scSiteId: string;
+  ga4PropertyId?: string;
+} {
+  const ga4PropertyId = site.ga4PropertyId?.trim();
+
+  return {
+    auditSiteId: site.id,
+    domain: site.domain.trim(),
+    scSiteId: getSCUrl(site),
+    ga4PropertyId: ga4PropertyId ? ga4PropertyId : undefined,
+  };
+}
+
+function unique(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+function shouldClearSitemapSyncState(
+  previous: ReturnType<typeof getCacheIdentities> | null,
+  next: ReturnType<typeof getCacheIdentities> | null,
+): boolean {
+  if (!previous || !next) return true;
+  return (
+    previous.auditSiteId !== next.auditSiteId ||
+    previous.domain !== next.domain ||
+    previous.scSiteId !== next.scSiteId
+  );
+}
+
+export function invalidateManagedSiteCache(previousSite: Site | null, nextSite: Site | null): void {
+  const previous = previousSite ? getCacheIdentities(previousSite) : null;
+  const next = nextSite ? getCacheIdentities(nextSite) : null;
+
+  const auditSiteIds = unique([previous?.auditSiteId, next?.auditSiteId]);
+
+  for (const siteId of auditSiteIds) {
+    clearCacheEntry('audit', siteId);
+  }
+
+  if (shouldClearSitemapSyncState(previous, next)) {
+    for (const siteId of auditSiteIds) {
+      clearSitemapSyncState(siteId);
+    }
+  }
+
+  for (const siteId of unique([previous?.scSiteId, next?.scSiteId])) {
+    clearCacheEntry('sitemap-submissions', siteId);
+    for (const prefix of SEARCH_CONSOLE_CACHE_PREFIXES) {
+      clearCacheEntriesByPrefix(prefix, siteId);
+    }
+  }
+
+  for (const propertyId of unique([previous?.ga4PropertyId, next?.ga4PropertyId])) {
+    for (const prefix of GA4_PROPERTY_CACHE_PREFIXES) {
+      clearCacheEntriesByPrefix(prefix, propertyId);
+    }
+  }
+}


### PR DESCRIPTION
Closes #49

Picked issue `#49`, commented on it, reused the existing issue branch, and implemented managed-site cache invalidation plus route tests.

---
Implemented via TamTam from issue [#49](https://github.com/3h4x/seo-tools/issues/49).