### PR TITLE
fix: Backfill missed daily gaps so trend charts recover after collector outages

### DIFF
--- a/src/lib/__tests__/collect-daily.test.ts
+++ b/src/lib/__tests__/collect-daily.test.ts
@@ -258,16 +258,18 @@ describe('startCollector', () => {
     expect(vi.getTimerCount()).toBe(1);
   });
 
-  it('only fetches dates after the latest collected date', async () => {
+  it('backfills from the full window when some dates exist at the end', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-02T12:00:00Z'));
 
     mockDbState({
-      latest: {
-        site1: '2026-04-20',
+      genesis: {
+        'sc:site1': '2026-04-01',
+        'ga4:site1': '2026-04-01',
       },
       existing: {
-        site1: ['2026-04-20'],
+        // Only the last day is present — all earlier dates should be backfilled
+        site1: ['2026-04-30'],
       },
     });
     mockSites();
@@ -281,13 +283,45 @@ describe('startCollector', () => {
       expect(runReport).toHaveBeenCalled();
     });
 
+    // Backfill should start from genesis, not from after MAX(date)
     expect(scQuery.mock.calls[0][0].requestBody).toMatchObject({
-      startDate: '2026-04-21',
-      endDate: '2026-04-30',
+      startDate: '2026-04-01',
     });
-    expect(runReport.mock.calls[0][0].dateRanges).toEqual([
-      { startDate: '2026-04-21', endDate: '2026-05-01' },
-    ]);
+    expect(runReport.mock.calls[0][0].dateRanges[0]).toMatchObject({
+      startDate: '2026-04-01',
+    });
+  });
+
+  it('backfills a missing middle date when endpoints are already stored', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+
+    mockDbState({
+      genesis: {
+        'sc:site1': '2026-04-01',
+        'ga4:site1': '2026-04-01',
+      },
+      existing: {
+        // 2026-04-02 is missing between 04-01 and 04-03
+        site1: ['2026-04-01', '2026-04-03', '2026-04-04', '2026-04-05', '2026-04-06', '2026-04-07', '2026-04-08'],
+      },
+    });
+    mockSites();
+    const { startCollector } = await loadCollectDailyModule();
+    const { scQuery, runReport } = mockClients();
+
+    startCollector();
+
+    await vi.waitFor(() => {
+      expect(scQuery).toHaveBeenCalled();
+      expect(runReport).toHaveBeenCalled();
+    });
+
+    // The first batch should be the isolated middle gap (2026-04-02)
+    expect(scQuery.mock.calls[0][0].requestBody).toMatchObject({
+      startDate: '2026-04-02',
+      endDate: '2026-04-02',
+    });
   });
 
   it('keeps a single continuous fetch range across the spring DST boundary', async () => {
@@ -295,8 +329,9 @@ describe('startCollector', () => {
     vi.setSystemTime(new Date('2026-04-02T12:00:00Z'));
 
     mockDbState({
-      latest: {
-        site1: '2026-03-27',
+      genesis: {
+        'sc:site1': '2026-03-27',
+        'ga4:site1': '2026-03-27',
       },
       existing: {
         site1: ['2026-03-27'],
@@ -353,17 +388,11 @@ describe('startCollector', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-02T12:00:00Z'));
 
-    const { genesisRun } = mockDbState({
-      latest: {
-        site1: '2026-04-29',
-      },
-      existing: {
-        site1: ['2026-04-29'],
-      },
-    });
+    // No existing data, no genesis — full window is scanned, API returns 0 rows
+    const { genesisRun } = mockDbState();
     mockSites();
     const { startCollector } = await loadCollectDailyModule();
-    const { scQuery, runReport } = mockClients();
+    mockClients(); // default: returns empty rows
 
     startCollector();
 
@@ -372,13 +401,7 @@ describe('startCollector', () => {
       expect(upsertGa4Daily).toHaveBeenCalledWith('site1', []);
     });
 
-    expect(scQuery.mock.calls[0][0].requestBody).toMatchObject({
-      startDate: '2026-04-30',
-      endDate: '2026-04-30',
-    });
-    expect(runReport.mock.calls[0][0].dateRanges).toEqual([
-      { startDate: '2026-04-30', endDate: '2026-05-01' },
-    ]);
+    // Genesis set to the day after each source's end-of-window
     expect(genesisRun).toHaveBeenCalledWith('site1', 'sc', '2026-05-01');
     expect(genesisRun).toHaveBeenCalledWith('site1', 'ga4', '2026-05-02');
   });

--- a/src/lib/collect-daily.ts
+++ b/src/lib/collect-daily.ts
@@ -46,23 +46,14 @@ function getMissingDates(table: string, siteId: string, source: string, startDat
   const genesis = getGenesis(siteId, source);
   const effectiveStart = genesis && genesis > startDate ? genesis : startDate;
 
-  // Find the latest date we already have — only fetch after that
-  const latestRow = db.prepare(
-    `SELECT MAX(date) as latest FROM ${table} WHERE site_id = ?`,
-  ).get(siteId) as { latest: string | null } | undefined;
-  const latest = latestRow?.latest;
-
-  // If we have data, only look for dates after the latest collected date
-  // (don't try to backfill old gaps)
-  const fetchFrom = latest && latest >= effectiveStart ? latest : effectiveStart;
-
+  // Scan the full bounded window to find all absent dates, including middle gaps
   const existing = db.prepare(
     `SELECT date FROM ${table} WHERE site_id = ? AND date >= ? AND date <= ?`,
-  ).all(siteId, fetchFrom, endDate) as Array<{ date: string }>;
+  ).all(siteId, effectiveStart, endDate) as Array<{ date: string }>;
   const existingSet = new Set(existing.map(r => r.date));
 
   const missing: string[] = [];
-  const cur = parseDateOnly(fetchFrom);
+  const cur = parseDateOnly(effectiveStart);
   const end = parseDateOnly(endDate);
   while (cur <= end) {
     const d = dateStr(cur);


### PR DESCRIPTION
Closes #50

**Summary:** Fixed issue #50 by removing the `MAX(date)` anchor from `getMissingDates` so the collector now scans the full bounded window and detects middle-date gaps, not just dates after the latest collected row.

**Files changed:** `src/lib/collect-daily.ts`, `src/lib/__tests__/collect-daily.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#50](https://github.com/3h4x/seo-tools/issues/50).