### PR TITLE
fix: Validate and normalize managed site config so bad input cannot poison audits

### DIFF
--- a/app/api/sites/route.ts
+++ b/app/api/sites/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '@/lib/db';
 import { invalidateManagedSiteCache } from '@/lib/site-cache';
-import { getSiteScUrlOverride, isValidSiteId, normalizeSiteDomain } from '@/lib/site-domain';
-import type { Site } from '@/lib/sites';
+import { validateAndNormalizeSiteInput } from '@/lib/sites';
 
 export async function GET() {
   const sites = dbGetSites();
@@ -10,32 +9,17 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json() as Site & { sortOrder?: number };
-  const { sortOrder, ...site } = body;
-  const id = typeof site.id === 'string' ? site.id.trim() : '';
-  const name = typeof site.name === 'string' ? site.name.trim() : '';
-  const rawDomain = typeof site.domain === 'string' ? site.domain.trim() : '';
-  const domain = rawDomain ? normalizeSiteDomain(rawDomain) : null;
-
-  if (!id || !isValidSiteId(id) || !name || !domain) {
-    return NextResponse.json({ ok: false, error: 'id, name, and valid domain are required' }, { status: 400 });
+  const body = await req.json();
+  const existingSites = dbGetSites();
+  const result = validateAndNormalizeSiteInput(body, existingSites);
+  if (result.errors) {
+    const error = Object.values(result.errors).filter(Boolean).join('; ');
+    return NextResponse.json({ ok: false, error, errors: result.errors }, { status: 400 });
   }
-
-  const scUrl = getSiteScUrlOverride(rawDomain, typeof site.scUrl === 'string' ? site.scUrl : undefined);
-  const normalizedSite: Site = {
-    ...site,
-    id,
-    name,
-    domain,
-    testPages: Array.isArray(site.testPages) ? site.testPages.map(page => page.trim()).filter(Boolean) : [],
-  };
-  if (scUrl) normalizedSite.scUrl = scUrl;
-  if (typeof site.ga4PropertyId === 'string') normalizedSite.ga4PropertyId = site.ga4PropertyId.trim() || undefined;
-  if (Array.isArray(site.skipChecks)) normalizedSite.skipChecks = site.skipChecks;
-
-  const previousSite = dbGetSites().find((managedSite) => managedSite.id === normalizedSite.id) ?? null;
-  dbUpsertSite(normalizedSite, sortOrder);
-  invalidateManagedSiteCache(previousSite, normalizedSite);
+  const { site, sortOrder } = result.normalized;
+  const previousSite = existingSites.find(s => s.id === site.id) ?? null;
+  dbUpsertSite(site, sortOrder);
+  invalidateManagedSiteCache(previousSite, site);
   return NextResponse.json({ ok: true });
 }
 

--- a/src/lib/__tests__/api-sites-delete.test.ts
+++ b/src/lib/__tests__/api-sites-delete.test.ts
@@ -118,7 +118,7 @@ describe('DELETE /api/sites integration', () => {
       name: 'Site A',
       domain: 'new.example.com',
       scUrl: 'sc-domain:new.example.com',
-      ga4PropertyId: 'ga4-new',
+      ga4PropertyId: 'properties/999',
       testPages: ['/fresh'],
     }));
 
@@ -130,7 +130,7 @@ describe('DELETE /api/sites integration', () => {
     ).toEqual({
       domain: 'new.example.com',
       sc_url: 'sc-domain:new.example.com',
-      ga4_property_id: 'ga4-new',
+      ga4_property_id: 'properties/999',
       test_pages: '["/fresh"]',
     });
 

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -10,6 +10,7 @@ vi.mock('../site-cache', () => ({
   invalidateManagedSiteCache: vi.fn(),
 }));
 
+// site-domain is used by sites.ts; do not mock it so validation logic runs for real
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '../db';
 import { invalidateManagedSiteCache } from '../site-cache';
 import { GET, POST, DELETE } from '../../../app/api/sites/route';
@@ -112,7 +113,7 @@ describe('POST /api/sites', () => {
       name: 'Site 1',
       domain: 'new.example.com',
       scUrl: 'sc-domain:new.example.com',
-      ga4PropertyId: '5678',
+      ga4PropertyId: 'properties/5678',
       testPages: ['/landing'],
       skipChecks: ['internalLinks'],
     };
@@ -130,6 +131,9 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.domain).toBeTruthy();
+    expect(typeof data.error).toBe('string');
+    expect(data.error).toContain(data.errors.domain);
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
@@ -139,6 +143,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.domain).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
@@ -148,6 +153,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.id).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
@@ -157,6 +163,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.id).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
@@ -166,6 +173,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.name).toBeTruthy();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
   });
 
@@ -174,7 +182,74 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+    expect(data.errors.domain).toBeTruthy();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when domain is a duplicate of an existing site with a different id', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'other', name: 'Other', domain: 'site1.com', testPages: [] },
+    ] as never);
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.domain).toMatch(/other/);
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+  });
+
+  it('allows saving a site whose domain matches its own existing record (update)', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: [] },
+    ] as never);
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1 Updated', domain: 'site1.com' }));
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid scUrl format', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', scUrl: 'not-a-valid-url' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.scUrl).toBeTruthy();
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+  });
+
+  it('accepts a scUrl with sc-domain: prefix', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', scUrl: 'sc-domain:site1.com' }));
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalled();
+  });
+
+  it('returns 400 for ga4PropertyId not in properties/NNNNNN format', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', ga4PropertyId: '123456' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.ga4PropertyId).toBeTruthy();
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid ga4PropertyId', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', ga4PropertyId: 'properties/123456' }));
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalled();
+  });
+
+  it('returns 400 when a testPage entry does not start with /', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: ['noslash'] }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.testPages).toBeTruthy();
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+  });
+
+  it('accepts valid testPages entries', async () => {
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: ['/', '/about'] }));
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalled();
   });
 });
 

--- a/src/lib/__tests__/discovery-import.test.ts
+++ b/src/lib/__tests__/discovery-import.test.ts
@@ -40,6 +40,22 @@ describe('getImportResult', () => {
       error: 'Validation failed',
     });
   });
+
+  it('surfaces the joined error string from a 400 with field-level errors payload', async () => {
+    const res = new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'domain is already used by site "other"; id is required',
+        errors: { domain: 'domain is already used by site "other"', id: 'id is required' },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+
+    await expect(getImportResult(res)).resolves.toEqual({
+      ok: false,
+      error: 'domain is already used by site "other"; id is required',
+    });
+  });
 });
 
 describe('applyImportResults', () => {

--- a/src/lib/__tests__/sites.test.ts
+++ b/src/lib/__tests__/sites.test.ts
@@ -4,7 +4,7 @@ vi.mock('../db', () => ({ dbGetSites: vi.fn() }));
 
 import { dbGetSites } from '../db';
 import { isValidSiteId } from '../site-domain';
-import { getSCUrl, getManagedSite, getManagedSites } from '../sites';
+import { getSCUrl, getManagedSite, getManagedSites, validateAndNormalizeSiteInput } from '../sites';
 import type { Site } from '../sites';
 
 function makeSite(overrides: Partial<Site> = {}): Site {
@@ -81,5 +81,137 @@ describe('isValidSiteId', () => {
     expect(isValidSiteId('//evil.example')).toBe(false);
     expect(isValidSiteId('site/one')).toBe(false);
     expect(isValidSiteId(' site ')).toBe(false);
+  });
+});
+
+describe('validateAndNormalizeSiteInput', () => {
+  it('returns normalized site for a minimal valid payload', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 'my-site', name: 'My Site', domain: 'mysite.com' },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site).toMatchObject({ id: 'my-site', name: 'My Site', domain: 'mysite.com', testPages: [] });
+  });
+
+  it('normalizes URL domain and sets scUrl automatically', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'https://EXAMPLE.COM/path' },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.domain).toBe('example.com');
+    expect(result.normalized?.site.scUrl).toBe('https://EXAMPLE.COM/path');
+  });
+
+  it('trims whitespace from id, name, domain', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: '  mysite  ', name: '  My Site  ', domain: '  mysite.com  ' },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.id).toBe('mysite');
+    expect(result.normalized?.site.name).toBe('My Site');
+    expect(result.normalized?.site.domain).toBe('mysite.com');
+  });
+
+  it('extracts sortOrder without including it in the site record', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', sortOrder: 5 },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized!.sortOrder).toBe(5);
+    expect((result.normalized!.site as unknown as Record<string, unknown>).sortOrder).toBeUndefined();
+  });
+
+  it('returns field error for missing id', () => {
+    const result = validateAndNormalizeSiteInput({ name: 'S', domain: 'site.com' }, []);
+    expect(result.errors?.id).toBeTruthy();
+    expect(result.normalized).toBeNull();
+  });
+
+  it('returns field error for invalid id', () => {
+    const result = validateAndNormalizeSiteInput({ id: '//bad', name: 'S', domain: 'site.com' }, []);
+    expect(result.errors?.id).toBeTruthy();
+  });
+
+  it('returns field error for missing name', () => {
+    const result = validateAndNormalizeSiteInput({ id: 's', domain: 'site.com' }, []);
+    expect(result.errors?.name).toBeTruthy();
+  });
+
+  it('returns field error for invalid domain', () => {
+    const result = validateAndNormalizeSiteInput({ id: 's', name: 'S', domain: 'bad..domain' }, []);
+    expect(result.errors?.domain).toBeTruthy();
+  });
+
+  it('returns field error when domain is already used by another site', () => {
+    const existing = makeSite({ id: 'other', domain: 'taken.com' });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'new-site', name: 'New', domain: 'taken.com' },
+      [existing],
+    );
+    expect(result.errors?.domain).toMatch(/other/);
+  });
+
+  it('allows update of a site with its own existing domain', () => {
+    const existing = makeSite({ id: 'mysite', domain: 'mysite.com' });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'mysite', name: 'Updated', domain: 'mysite.com' },
+      [existing],
+    );
+    expect(result.errors).toBeNull();
+  });
+
+  it('returns field error for invalid scUrl', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', scUrl: 'not-a-url' },
+      [],
+    );
+    expect(result.errors?.scUrl).toBeTruthy();
+  });
+
+  it('accepts sc-domain: scUrl', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', scUrl: 'sc-domain:site.com' },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.scUrl).toBe('sc-domain:site.com');
+  });
+
+  it('returns field error for ga4PropertyId not matching properties/NNNNNN', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', ga4PropertyId: '123456' },
+      [],
+    );
+    expect(result.errors?.ga4PropertyId).toBeTruthy();
+  });
+
+  it('accepts a valid ga4PropertyId', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', ga4PropertyId: 'properties/123456' },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.ga4PropertyId).toBe('properties/123456');
+  });
+
+  it('returns field error when a testPage does not start with /', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', testPages: ['/ok', 'bad'] },
+      [],
+    );
+    expect(result.errors?.testPages).toBeTruthy();
+  });
+
+  it('accepts valid testPages', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', testPages: ['/', '/about'] },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.testPages).toEqual(['/', '/about']);
   });
 });

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -12,6 +12,20 @@ export interface Site {
   skipChecks?: string[];
 }
 
+export interface SiteFieldErrors {
+  id?: string;
+  name?: string;
+  domain?: string;
+  scUrl?: string;
+  ga4PropertyId?: string;
+  testPages?: string;
+}
+
+export interface NormalizedSiteInput {
+  site: Site;
+  sortOrder?: number;
+}
+
 /** Returns the URL to use for Search Console API calls for a given site. */
 export function getSCUrl(site: Site): string {
   const url = site.scUrl ?? site.domain;
@@ -20,6 +34,73 @@ export function getSCUrl(site: Site): string {
 }
 
 import { dbGetSites } from './db';
+import { normalizeSiteDomain, isValidSiteId, getSiteScUrlOverride } from './site-domain';
+
+const GA4_PROPERTY_RE = /^properties\/\d+$/;
+
+export function validateAndNormalizeSiteInput(
+  raw: unknown,
+  existingSites: Site[],
+): { errors: SiteFieldErrors; normalized: null } | { errors: null; normalized: NormalizedSiteInput } {
+  const body = raw as Record<string, unknown>;
+  const errors: SiteFieldErrors = {};
+
+  const id = typeof body.id === 'string' ? body.id.trim() : '';
+  if (!id) {
+    errors.id = 'id is required';
+  } else if (!isValidSiteId(id)) {
+    errors.id = 'id must contain only letters, digits, hyphens, underscores, or dots and must not start with a special character';
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name) errors.name = 'name is required';
+
+  const rawDomain = typeof body.domain === 'string' ? body.domain.trim() : '';
+  const normalizedDomain = rawDomain ? normalizeSiteDomain(rawDomain) : null;
+  if (!rawDomain) {
+    errors.domain = 'domain is required';
+  } else if (!normalizedDomain) {
+    errors.domain = 'domain must be a valid hostname or URL (e.g. example.com or https://example.com)';
+  } else {
+    const duplicate = existingSites.find(s => s.domain === normalizedDomain && s.id !== id);
+    if (duplicate) errors.domain = `domain is already used by site "${duplicate.id}"`;
+  }
+
+  const rawScUrl = typeof body.scUrl === 'string' ? body.scUrl.trim() : '';
+  if (rawScUrl && !rawScUrl.startsWith('sc-domain:') && !/^https?:\/\//i.test(rawScUrl)) {
+    errors.scUrl = 'scUrl must be a valid URL (https://…) or use the sc-domain: prefix';
+  }
+
+  const rawGa4 = typeof body.ga4PropertyId === 'string' ? body.ga4PropertyId.trim() : '';
+  if (rawGa4 && !GA4_PROPERTY_RE.test(rawGa4)) {
+    errors.ga4PropertyId = 'ga4PropertyId must be in the format properties/NNNNNN';
+  }
+
+  const rawTestPages = Array.isArray(body.testPages) ? body.testPages : [];
+  const badPage = rawTestPages.find(p => typeof p !== 'string' || !String(p).trim().startsWith('/'));
+  if (badPage !== undefined) {
+    errors.testPages = 'each testPages entry must be an absolute path starting with /';
+  }
+
+  if (Object.keys(errors).length > 0) return { errors, normalized: null };
+
+  const scUrl = getSiteScUrlOverride(rawDomain, rawScUrl || undefined);
+  const site: Site = {
+    ...(raw as Site),
+    id,
+    name,
+    domain: normalizedDomain!,
+    testPages: rawTestPages.map(p => String(p).trim()).filter(Boolean),
+  };
+  if (scUrl) site.scUrl = scUrl; else delete site.scUrl;
+  if (rawGa4) site.ga4PropertyId = rawGa4; else delete site.ga4PropertyId;
+  if (!Array.isArray(body.skipChecks)) delete site.skipChecks;
+
+  const sortOrder = typeof body.sortOrder === 'number' ? body.sortOrder : undefined;
+  delete (site as unknown as Record<string, unknown>).sortOrder;
+
+  return { errors: null, normalized: { site, sortOrder } };
+}
 
 export async function getManagedSites(): Promise<Site[]> {
   return dbGetSites();


### PR DESCRIPTION
Closes #52

**Summary:** Implemented issue #52 — centralized site validation and normalization in `src/lib/sites.ts` with field-level errors returned from `POST /api/sites`, covering id format, duplicate domains, scUrl format, ga4PropertyId format, and testPages path validation.

**Files changed:** `src/lib/sites.ts`, `app/api/sites/route.ts`, `src/lib/__tests__/sites.test.ts`, `src/lib/__tests__/api-sites.test.ts`, `src/lib/__tests__/api-sites-delete.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#52](https://github.com/3h4x/seo-tools/issues/52).