### PR TITLE
chore(review): legacy url prefix domain duplicate discovery

### DIFF
--- a/app/api/cache/route.ts
+++ b/app/api/cache/route.ts
@@ -1,7 +1,9 @@
 import { clearCache } from '@/lib/db';
+import { clearGa4DiscoveryCache } from '@/lib/ga4';
 import { NextResponse } from 'next/server';
 
 export async function DELETE() {
   clearCache();
+  clearGa4DiscoveryCache();
   return NextResponse.json({ cleared: true });
 }

--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -1,6 +1,7 @@
 import { GoogleAuth } from 'google-auth-library';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { createConfigRouteHandlers } from '@/lib/config-route';
+import { clearGa4DiscoveryCache } from '@/lib/ga4';
 
 const SCOPES = [
   'https://www.googleapis.com/auth/webmasters',
@@ -36,5 +37,6 @@ async function validateKey(raw: string): Promise<string> {
 export const { GET, POST, DELETE } = createConfigRouteHandlers({
   configKey: 'google_sa_key',
   envKey: 'GOOGLE_SA_KEY_JSON',
+  afterMutate: clearGa4DiscoveryCache,
   validateAndNormalize: validateKey,
 });

--- a/app/api/sites/discover/route.ts
+++ b/app/api/sites/discover/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getAuth } from '@/lib/google-auth';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
-import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { dbGetSites } from '@/lib/db';
+import { cachedGetDiscoveredGa4Properties } from '@/lib/ga4';
 import { normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
 import { getSCUrl, type Site } from '@/lib/sites';
 
@@ -96,17 +96,14 @@ export async function GET(req: Request) {
   // Fetch GA4 properties (best-effort)
   const ga4Map = new Map<string, string>(); // display name → propertyId
   try {
-    const adminClient = new AnalyticsAdminServiceClient({ auth });
-    const [summaries] = await adminClient.listAccountSummaries({});
-    for (const account of summaries) {
-      for (const prop of account.propertySummaries ?? []) {
-        const name = (prop.displayName ?? '').toLowerCase();
-        const propId = prop.property?.split('/')[1] ?? '';
-        if (propId) ga4Map.set(name, propId);
-      }
+    const properties = await cachedGetDiscoveredGa4Properties();
+    for (const property of properties ?? []) {
+      const displayName = property.displayName.trim().toLowerCase();
+      const propertyId = property.propertyId.trim();
+      if (displayName && propertyId) ga4Map.set(displayName, propertyId);
     }
   } catch {
-    // GA4 discovery is best-effort; proceed without it
+    // GA4 discovery is best-effort; proceed without it.
   }
 
   // Debug: return raw GA4 property names

--- a/app/api/sites/route.ts
+++ b/app/api/sites/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '@/lib/db';
+import { clearGa4DiscoveryCache } from '@/lib/ga4';
 import { invalidateManagedSiteCache } from '@/lib/site-cache';
 import { validateAndNormalizeSiteInput } from '@/lib/sites';
 
@@ -20,6 +21,7 @@ export async function POST(req: NextRequest) {
   const previousSite = existingSites.find(s => s.id === site.id) ?? null;
   dbUpsertSite(site, sortOrder);
   invalidateManagedSiteCache(previousSite, site);
+  clearGa4DiscoveryCache();
   return NextResponse.json({ ok: true });
 }
 
@@ -33,5 +35,6 @@ export async function DELETE(req: NextRequest) {
   if (previousSite) {
     invalidateManagedSiteCache(previousSite, null);
   }
+  clearGa4DiscoveryCache();
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/__tests__/api-cache.test.ts
+++ b/src/lib/__tests__/api-cache.test.ts
@@ -4,7 +4,12 @@ vi.mock('../db', () => ({
   clearCache: vi.fn(),
 }));
 
+vi.mock('../ga4', () => ({
+  clearGa4DiscoveryCache: vi.fn(),
+}));
+
 import { clearCache } from '../db';
+import { clearGa4DiscoveryCache } from '../ga4';
 import { DELETE } from '../../../app/api/cache/route';
 
 beforeEach(() => {
@@ -17,6 +22,7 @@ describe('DELETE /api/cache', () => {
     const data = await res.json();
     expect(data).toEqual({ cleared: true });
     expect(clearCache).toHaveBeenCalledTimes(1);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('returns 200 status', async () => {

--- a/src/lib/__tests__/api-config.test.ts
+++ b/src/lib/__tests__/api-config.test.ts
@@ -7,6 +7,10 @@ vi.mock('../db', () => ({
   clearCache: vi.fn(),
 }));
 
+vi.mock('../ga4', () => ({
+  clearGa4DiscoveryCache: vi.fn(),
+}));
+
 vi.mock('google-auth-library', () => ({
   GoogleAuth: vi.fn(),
 }));
@@ -18,6 +22,7 @@ vi.mock('@googleapis/searchconsole', () => ({
 }));
 
 import { getConfig, setConfig, deleteConfig, clearCache } from '../db';
+import { clearGa4DiscoveryCache } from '../ga4';
 import { GoogleAuth } from 'google-auth-library';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { GET, POST, DELETE } from '../../../app/api/config/route';
@@ -117,6 +122,7 @@ describe('POST /api/config', () => {
     expect(body.ok).toBe(true);
     expect(setConfig).not.toHaveBeenCalled();
     expect(clearCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('saves key and clears cache when testOnly=false', async () => {
@@ -126,6 +132,7 @@ describe('POST /api/config', () => {
     expect(body.ok).toBe(true);
     expect(setConfig).toHaveBeenCalledWith('google_sa_key', VALID_KEY);
     expect(clearCache).toHaveBeenCalledTimes(1);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('saves key when testOnly is omitted', async () => {
@@ -135,6 +142,7 @@ describe('POST /api/config', () => {
     expect(body.ok).toBe(true);
     expect(setConfig).toHaveBeenCalledWith('google_sa_key', VALID_KEY);
     expect(clearCache).toHaveBeenCalledTimes(1);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('normalizes escaped newlines in private_key before validation', async () => {
@@ -164,5 +172,6 @@ describe('DELETE /api/config', () => {
     expect(body).toEqual({ ok: true });
     expect(deleteConfig).toHaveBeenCalledWith('google_sa_key');
     expect(clearCache).toHaveBeenCalledTimes(1);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/__tests__/api-discover.test.ts
+++ b/src/lib/__tests__/api-discover.test.ts
@@ -6,19 +6,19 @@ vi.mock('../google-auth', () => ({
 vi.mock('../db', () => ({
   dbGetSites: vi.fn(),
 }));
+vi.mock('../ga4', () => ({
+  cachedGetDiscoveredGa4Properties: vi.fn(),
+}));
 vi.mock('@googleapis/searchconsole', () => ({
   searchconsole_v1: {
     Searchconsole: vi.fn(),
   },
 }));
-vi.mock('@google-analytics/admin', () => ({
-  AnalyticsAdminServiceClient: vi.fn(),
-}));
 
 import { getAuth } from '../google-auth';
 import { dbGetSites } from '../db';
+import { cachedGetDiscoveredGa4Properties } from '../ga4';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
-import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { GET } from '../../../app/api/sites/discover/route';
 import { NextRequest } from 'next/server';
 
@@ -48,13 +48,12 @@ function mockSc(domains: string[]) {
 }
 
 function mockGa4(properties: Array<{ displayName: string; property: string }>) {
-  vi.mocked(AnalyticsAdminServiceClient).mockImplementation(function () {
-    return {
-      listAccountSummaries: vi.fn().mockResolvedValue([
-        [{ propertySummaries: properties }],
-      ]),
-    };
-  } as never);
+  vi.mocked(cachedGetDiscoveredGa4Properties).mockResolvedValue(
+    properties.map(({ displayName, property }) => ({
+      displayName,
+      propertyId: property.replace(/^properties\//, ''),
+    })) as never,
+  );
 }
 
 describe('GET /api/sites/discover', () => {
@@ -300,11 +299,7 @@ describe('GET /api/sites/discover', () => {
 
   it('proceeds without GA4 when admin API throws', async () => {
     mockSc(['mysite.com']);
-    vi.mocked(AnalyticsAdminServiceClient).mockImplementation(function () {
-      return {
-        listAccountSummaries: vi.fn().mockRejectedValue(new Error('Admin API failed')),
-      };
-    } as never);
+    vi.mocked(cachedGetDiscoveredGa4Properties).mockRejectedValue(new Error('Admin API failed') as never);
 
     const res = await GET(getReq());
     expect(res.status).toBe(200);

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -10,8 +10,13 @@ vi.mock('../site-cache', () => ({
   invalidateManagedSiteCache: vi.fn(),
 }));
 
+vi.mock('../ga4', () => ({
+  clearGa4DiscoveryCache: vi.fn(),
+}));
+
 // site-domain is used by sites.ts; do not mock it so validation logic runs for real
 import { dbGetSites, dbUpsertSite, dbDeleteSite } from '../db';
+import { clearGa4DiscoveryCache } from '../ga4';
 import { invalidateManagedSiteCache } from '../site-cache';
 import { GET, POST, DELETE } from '../../../app/api/sites/route';
 import { NextRequest } from 'next/server';
@@ -60,6 +65,7 @@ describe('POST /api/sites', () => {
     expect(data).toEqual({ ok: true });
     expect(dbUpsertSite).toHaveBeenCalledWith({ ...site, testPages: [] }, undefined);
     expect(invalidateManagedSiteCache).toHaveBeenCalledWith(null, { ...site, testPages: [] });
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('normalizes URL domains before saving', async () => {
@@ -124,6 +130,7 @@ describe('POST /api/sites', () => {
     expect(res.status).toBe(200);
     expect(dbUpsertSite).toHaveBeenCalledWith(updatedSite, undefined);
     expect(invalidateManagedSiteCache).toHaveBeenCalledWith(existingSite, updatedSite);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('returns 400 for URL values without a valid hostname', async () => {
@@ -136,6 +143,7 @@ describe('POST /api/sites', () => {
     expect(data.error).toContain(data.errors.domain);
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 for malformed bare domains', async () => {
@@ -146,6 +154,7 @@ describe('POST /api/sites', () => {
     expect(data.errors.domain).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when id is missing', async () => {
@@ -156,6 +165,7 @@ describe('POST /api/sites', () => {
     expect(data.errors.id).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when id is not a safe route segment', async () => {
@@ -175,6 +185,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.name).toBeTruthy();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when domain is missing', async () => {
@@ -184,6 +195,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.domain).toBeTruthy();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when domain is a duplicate of an existing site with a different id', async () => {
@@ -196,6 +208,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.domain).toMatch(/other/);
     expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('allows saving a site whose domain matches its own existing record (update)', async () => {
@@ -214,6 +227,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.scUrl).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('accepts a scUrl with sc-domain: prefix', async () => {
@@ -229,6 +243,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.ga4PropertyId).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('accepts a valid ga4PropertyId', async () => {
@@ -244,6 +259,7 @@ describe('POST /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(data.errors.testPages).toBeTruthy();
     expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('accepts valid testPages entries', async () => {
@@ -263,6 +279,7 @@ describe('DELETE /api/sites', () => {
     expect(data).toEqual({ ok: true });
     expect(dbDeleteSite).toHaveBeenCalledWith('site1');
     expect(invalidateManagedSiteCache).toHaveBeenCalledWith(existingSite, null);
+    expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
 
   it('returns 400 when id query param is missing', async () => {
@@ -273,6 +290,7 @@ describe('DELETE /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(dbDeleteSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 
   it('returns 400 when id query param is empty', async () => {
@@ -282,5 +300,6 @@ describe('DELETE /api/sites', () => {
     expect(data.ok).toBe(false);
     expect(dbDeleteSite).not.toHaveBeenCalled();
     expect(invalidateManagedSiteCache).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -15,13 +15,15 @@ vi.mock('@google-analytics/data', () => ({
   },
 }));
 vi.mock('../db', () => ({
+  clearCacheEntry: vi.fn(),
   withCache: vi.fn((_key: string, _id: string, fn: () => unknown) => fn()),
 }));
 vi.mock('../sites', () => ({
   getManagedSites: vi.fn(),
 }));
 
-import { discoverPropertyIds, cachedGetAnalytics } from '../ga4';
+import { clearCacheEntry, withCache } from '../db';
+import { cachedGetDiscoveredGa4Properties, clearGa4DiscoveryCache, discoverPropertyIds, cachedGetAnalytics } from '../ga4';
 import { getManagedSites } from '../sites';
 
 beforeEach(() => {
@@ -31,6 +33,22 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 // discoverPropertyIds
 // ---------------------------------------------------------------------------
+
+describe('cachedGetDiscoveredGa4Properties', () => {
+  it('uses the dedicated discovery cache key', async () => {
+    mockListAccountSummaries.mockResolvedValue([
+      [{ propertySummaries: [{ displayName: 'example.com', property: 'properties/12345' }] }],
+    ]);
+
+    await cachedGetDiscoveredGa4Properties();
+
+    expect(withCache).toHaveBeenCalledWith(
+      'ga4-discovery',
+      'managed-sites',
+      expect.any(Function),
+    );
+  });
+});
 
 describe('discoverPropertyIds', () => {
   it('matches property by domain name substring', async () => {
@@ -78,6 +96,27 @@ describe('discoverPropertyIds', () => {
     expect(result).toEqual(sites);
   });
 
+  it('returns sites unchanged when cached property discovery misses', async () => {
+    const sites = [{ id: 's1', name: 'Site1', domain: 'example.com', testPages: [] }];
+    vi.mocked(getManagedSites).mockResolvedValue(sites as never);
+    vi.mocked(withCache).mockResolvedValueOnce(null as never);
+
+    const result = await discoverPropertyIds();
+
+    expect(result).toEqual(sites);
+    expect(mockListAccountSummaries).not.toHaveBeenCalled();
+  });
+
+  it('returns sites unchanged when cached property discovery throws', async () => {
+    const sites = [{ id: 's1', name: 'Site1', domain: 'example.com', testPages: [] }];
+    vi.mocked(getManagedSites).mockResolvedValue(sites as never);
+    vi.mocked(withCache).mockRejectedValueOnce(new Error('cache failure') as never);
+
+    const result = await discoverPropertyIds();
+
+    expect(result).toEqual(sites);
+  });
+
   it('handles accounts with no propertySummaries', async () => {
     vi.mocked(getManagedSites).mockResolvedValue([
       { id: 's1', name: 'Site1', domain: 'example.com', testPages: [] },
@@ -122,6 +161,13 @@ describe('discoverPropertyIds', () => {
 
     const result = await discoverPropertyIds();
     expect(result[0].ga4PropertyId).toBeUndefined();
+  });
+});
+
+describe('clearGa4DiscoveryCache', () => {
+  it('clears the dedicated GA4 discovery cache entry', () => {
+    clearGa4DiscoveryCache();
+    expect(clearCacheEntry).toHaveBeenCalledWith('ga4-discovery', 'managed-sites');
   });
 });
 

--- a/src/lib/config-route.ts
+++ b/src/lib/config-route.ts
@@ -7,6 +7,7 @@ type ConfigRouteOptions = {
   configKey: string;
   envKey?: string;
   clearCachePrefix?: string;
+  afterMutate?: () => void;
   validateAndNormalize: (raw: string) => Promise<string>;
 };
 
@@ -25,6 +26,7 @@ export function createConfigRouteHandlers({
   configKey,
   envKey,
   clearCachePrefix,
+  afterMutate,
   validateAndNormalize,
 }: ConfigRouteOptions) {
   return {
@@ -41,6 +43,7 @@ export function createConfigRouteHandlers({
         if (!testOnly) {
           setConfig(configKey, normalizedKey);
           clearCache(clearCachePrefix);
+          afterMutate?.();
         }
 
         return NextResponse.json({ ok: true });
@@ -52,6 +55,7 @@ export function createConfigRouteHandlers({
     DELETE() {
       deleteConfig(configKey);
       clearCache(clearCachePrefix);
+      afterMutate?.();
       return NextResponse.json({ ok: true });
     },
   };

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -2,7 +2,15 @@ import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getManagedSites } from './sites';
-import { withCache } from './db';
+import { clearCacheEntry, withCache } from './db';
+
+const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
+const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
+
+type DiscoveredGa4Property = {
+  displayName: string;
+  propertyId: string;
+};
 
 function getAdminClient() {
   return new AnalyticsAdminServiceClient({ auth: getAuth() });
@@ -11,30 +19,55 @@ function getDataClient() {
   return new BetaAnalyticsDataClient({ auth: getAuth() });
 }
 
-export async function discoverPropertyIds() {
-  const sites = await getManagedSites();
+async function fetchDiscoveredGa4Properties(): Promise<DiscoveredGa4Property[] | null> {
   try {
     const [summaries] = await getAdminClient().listAccountSummaries({});
-    const properties = summaries.flatMap((account) => account.propertySummaries || []);
+    return summaries.flatMap((account) => (
+      (account.propertySummaries ?? []).flatMap((property) => {
+        const displayName = property.displayName?.trim();
+        const propertyId = property.property?.split('/')[1]?.trim();
+        if (!displayName || !propertyId) return [];
+        return [{ displayName, propertyId }];
+      })
+    ));
+  } catch (error) {
+    console.error('Error discovering GA4 properties:', error);
+    return null;
+  }
+}
 
-    return sites.map((site) => {
+export async function cachedGetDiscoveredGa4Properties(): Promise<DiscoveredGa4Property[] | null> {
+  return withCache<DiscoveredGa4Property[]>(
+    GA4_DISCOVERY_CACHE_KEY,
+    GA4_DISCOVERY_CACHE_SITE_ID,
+    fetchDiscoveredGa4Properties,
+  );
+}
+
+export function clearGa4DiscoveryCache(): void {
+  clearCacheEntry(GA4_DISCOVERY_CACHE_KEY, GA4_DISCOVERY_CACHE_SITE_ID);
+}
+
+export async function discoverPropertyIds() {
+  const sites = await getManagedSites();
+  const properties = await cachedGetDiscoveredGa4Properties().catch((error) => {
+    console.error('Error discovering GA4 properties:', error);
+    return null;
+  });
+  if (!properties) return sites;
+
+  return sites.map((site) => {
+      const domain = site.domain.toLowerCase();
       const property = properties.find((p) => {
-        const displayName = p.displayName?.toLowerCase();
-        if (!displayName) return false;
-
-        const domain = site.domain.toLowerCase();
+        const displayName = p.displayName.toLowerCase();
         return displayName.includes(domain) || domain.includes(displayName);
       });
 
       return {
         ...site,
-        ga4PropertyId: site.ga4PropertyId || property?.property?.split('/')[1],
+        ga4PropertyId: site.ga4PropertyId || property?.propertyId,
       };
     });
-  } catch (error) {
-    console.error('Error discovering GA4 properties:', error);
-    return sites;
-  }
 }
 
 interface GA4Metrics {


### PR DESCRIPTION
Closes #58

Implemented issue `#48` by adding dedicated GA4 discovery caching plus invalidation hooks and test coverage updates.

---
Implemented via TamTam from issue [#58](https://github.com/3h4x/seo-tools/issues/58).