### PR TITLE
fix: Let discovery backfill existing managed sites so GA4 matches can be repaired from Config

### DIFF
--- a/app/api/sites/discover/route.ts
+++ b/app/api/sites/discover/route.ts
@@ -111,32 +111,41 @@ export async function GET(req: Request) {
     return NextResponse.json(Object.fromEntries(ga4Map));
   }
 
+  function matchGa4(domain: string): string | undefined {
+    const domainLower = domain.toLowerCase();
+    for (const [name, propId] of ga4Map.entries()) {
+      if (name.includes(domainLower) || domainLower.includes(name)) {
+        // Return in properties/NNNNNN format so it passes site validation on import
+        return propId.startsWith('properties/') ? propId : `properties/${propId}`;
+      }
+    }
+    return undefined;
+  }
+
   // Build proposed sites from SC domains not already in DB
-  const proposed: Site[] = scSites
+  const proposed: (Site & { isUpdate?: boolean })[] = scSites
     .filter(({ domain, scUrls }) => (
       !existingDomains.has(domain.toLowerCase()) &&
       scUrls.every(scUrl => !existingScIdentities.has(normalizeScIdentity(scUrl)))
     ))
-    .map(({ domain, scUrl }) => {
-      const domainLower = domain.toLowerCase();
-      let ga4PropertyId: string | undefined;
-      for (const [name, propId] of ga4Map.entries()) {
-        if (name.includes(domainLower) || domainLower.includes(name)) {
-          ga4PropertyId = propId;
-          break;
-        }
-      }
+    .map(({ domain, scUrl }) => ({
+      id: slugifySiteDomain(domain),
+      name: domain,
+      domain,
+      scUrl: /^https?:\/\//i.test(scUrl) ? scUrl : undefined,
+      searchConsole: true,
+      testPages: ['/'],
+      ga4PropertyId: matchGa4(domain),
+    }));
 
-      return {
-        id: slugifySiteDomain(domain),
-        name: domain,
-        domain,
-        scUrl: /^https?:\/\//i.test(scUrl) ? scUrl : undefined,
-        searchConsole: true,
-        testPages: ['/'],
-        ga4PropertyId,
-      };
+  // Backfill existing sites that are missing a GA4 property ID but now have a discovered match
+  const backfill: (Site & { isUpdate: boolean })[] = existingSites
+    .filter(site => !site.ga4PropertyId)
+    .flatMap(site => {
+      const ga4PropertyId = matchGa4(site.domain);
+      if (!ga4PropertyId) return [];
+      return [{ ...site, ga4PropertyId, isUpdate: true }];
     });
 
-  return NextResponse.json(proposed);
+  return NextResponse.json([...proposed, ...backfill]);
 }

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -14,6 +14,7 @@ interface Site {
   color?: string;
   testPages: string[];
   skipChecks?: string[];
+  isUpdate?: boolean;
 }
 
 interface Props {
@@ -179,7 +180,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     try {
       const results = await Promise.all(toImport.map(async (site): Promise<ImportResult> => {
         try {
-          const { importError: _importError, ...siteToSave } = site;
+          const { importError: _importError, isUpdate: _isUpdate, ...siteToSave } = site;
           const res = await fetch('/api/sites', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -473,7 +474,14 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                   >
                     {selected.size === discovered.length ? 'Deselect All' : 'Select All'}
                   </button>
-                  <span className="text-xs text-neutral-600">{discovered.length} new site{discovered.length !== 1 ? 's' : ''} found</span>
+                  {(() => {
+                    const newCount = discovered.filter(s => !s.isUpdate).length;
+                    const updateCount = discovered.filter(s => s.isUpdate).length;
+                    const parts = [];
+                    if (newCount > 0) parts.push(`${newCount} new site${newCount !== 1 ? 's' : ''}`);
+                    if (updateCount > 0) parts.push(`${updateCount} to update`);
+                    return <span className="text-xs text-neutral-600">{parts.join(', ')} found</span>;
+                  })()}
                 </div>
                 <div className="space-y-2">
                   {discovered.map(site => (
@@ -486,6 +494,9 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                           className="rounded border-neutral-600"
                         />
                         <span className="text-sm text-white">{site.domain}</span>
+                        {site.isUpdate && (
+                          <span className="text-xs text-amber-400 border border-amber-700 rounded px-1">update</span>
+                        )}
                         {site.ga4PropertyId && (
                           <span className="text-xs text-neutral-500">GA4: {site.ga4PropertyId}</span>
                         )}

--- a/src/lib/__tests__/api-discover.test.ts
+++ b/src/lib/__tests__/api-discover.test.ts
@@ -120,7 +120,7 @@ describe('GET /api/sites/discover', () => {
 
     const res = await GET(getReq());
     const body = await res.json();
-    expect(body[0].ga4PropertyId).toBe('123456');
+    expect(body[0].ga4PropertyId).toBe('properties/123456');
   });
 
   it('matches GA4 property when SC returns a URL-prefix property', async () => {
@@ -141,7 +141,7 @@ describe('GET /api/sites/discover', () => {
     const body = await res.json();
     expect(body[0].domain).toBe('blog.example.com');
     expect(body[0].scUrl).toBe('https://blog.example.com/');
-    expect(body[0].ga4PropertyId).toBe('654321');
+    expect(body[0].ga4PropertyId).toBe('properties/654321');
   });
 
   it('dedupes domain and URL-prefix properties for the same hostname', async () => {
@@ -167,7 +167,7 @@ describe('GET /api/sites/discover', () => {
     expect(body[0]).toMatchObject({
       id: 'example-com',
       domain: 'example.com',
-      ga4PropertyId: '123',
+      ga4PropertyId: 'properties/123',
     });
     expect(body[0].scUrl).toBeUndefined();
   });
@@ -389,5 +389,67 @@ describe('GET /api/sites/discover', () => {
     const body = await res.json();
     expect(body).not.toHaveProperty('mysite.com');
     expect(body).toHaveProperty('mysite.com analytics', '321');
+  });
+
+  it('backfills existing site missing GA4 when a match is found', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: undefined },
+    ] as never);
+    mockSc([]); // already in DB, won't appear in proposed
+    mockGa4([{ displayName: 'mysite.com - GA4', property: 'properties/111' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'mysite-com',
+      domain: 'mysite.com',
+      ga4PropertyId: 'properties/111',
+      isUpdate: true,
+    });
+  });
+
+  it('does not backfill existing site that already has a GA4 property ID', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: '999' },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'mysite.com GA4', property: 'properties/111' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('does not backfill existing site when no GA4 match found', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: undefined },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'unrelated project', property: 'properties/777' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('returns both new and backfill sites when both match', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'existing-com', name: 'Existing', domain: 'existing.com', testPages: ['/'], ga4PropertyId: undefined },
+    ] as never);
+    mockSc(['newsite.com']); // new site not in DB
+    mockGa4([
+      { displayName: 'existing.com GA4', property: 'properties/100' },
+      { displayName: 'newsite.com GA4', property: 'properties/200' },
+    ]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    const backfill = body.find((s: { id: string }) => s.id === 'existing-com');
+    const proposed = body.find((s: { id: string }) => s.id === 'newsite-com');
+    expect(backfill).toMatchObject({ isUpdate: true, ga4PropertyId: 'properties/100' });
+    expect(proposed).toMatchObject({ ga4PropertyId: 'properties/200' });
+    expect(proposed?.isUpdate).toBeUndefined();
   });
 });

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -102,7 +102,7 @@ async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Da
   if (!propertyId) return null;
 
   try {
-    const prop = `properties/${propertyId}`;
+    const prop = propertyId.startsWith('properties/') ? propertyId : `properties/${propertyId}`;
 
     const dataClient = getDataClient();
     const [metricsRes, topPagesRes, trafficRes] = await Promise.all([


### PR DESCRIPTION
Closes #46

**Summary:** Implemented issue #46 — discovery now backfills existing managed sites that are missing a GA4 property ID when a GA4 match is found, allowing repairs directly from the Config tab without manual entry.

**Files changed:** `app/api/sites/discover/route.ts`, `app/components/sites-manager.tsx`, `src/lib/ga4.ts`, `src/lib/__tests__/api-discover.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#46](https://github.com/3h4x/seo-tools/issues/46).