### PR TITLE
fix: Stop showing provider failures as zero SEO metrics so the dashboard does not silently lie

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -95,9 +95,12 @@ export default async function SiteDashboardPage({
   const sections = gapsBySection(gapAnalysis.gaps);
   const totalGaps = gapAnalysis.gaps.length;
 
-  const sc = scComparison;
+  const sc = scComparison?.data ?? null;
+  const scError = scComparison?.error ?? false;
   const hasSc = sc && sc.current.clicks > 0;
-  const hasGa4 = ga4Data && ga4Data.current.users > 0;
+  const ga4 = ga4Data.data;
+  const ga4Error = ga4Data.error;
+  const hasGa4 = ga4 && ga4.current.users > 0;
   const queryBucketStats = scQueries ? getQueryBucketStats(scQueries) : [];
 
   let scDaily: ReturnType<typeof getScDaily> = [];
@@ -142,7 +145,10 @@ export default async function SiteDashboardPage({
         )}
       </div>
       <div>
-        <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Search Console</h2>
+        <div className="flex items-center gap-3 mb-3">
+          <h2 className="text-xs uppercase tracking-wider text-neutral-500 font-semibold">Search Console</h2>
+          {scError && <span className="text-xs text-red-400">data unavailable</span>}
+        </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <MetricCard icon={Icons.clicks} label="Clicks" current={sc?.current.clicks ?? 0} previous={sc?.previous.clicks} accent="border-emerald-500" />
           <MetricCard icon={Icons.impressions} label="Impressions" current={sc?.current.impressions ?? 0} previous={sc?.previous.impressions} accent="border-cyan-500" />
@@ -151,13 +157,16 @@ export default async function SiteDashboardPage({
         </div>
       </div>
       <div>
-        <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">GA4 Analytics</h2>
+        <div className="flex items-center gap-3 mb-3">
+          <h2 className="text-xs uppercase tracking-wider text-neutral-500 font-semibold">GA4 Analytics</h2>
+          {ga4Error && <span className="text-xs text-red-400">data unavailable</span>}
+        </div>
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-          <MetricCard icon={Icons.users} label="Users" current={ga4Data?.current.users ?? 0} previous={ga4Data?.previous.users} accent="border-blue-500" />
-          <MetricCard icon={Icons.sessions} label="Sessions" current={ga4Data?.current.sessions ?? 0} previous={ga4Data?.previous.sessions} accent="border-pink-500" />
-          <MetricCard icon={Icons.views} label="Page Views" current={ga4Data?.current.views ?? 0} previous={ga4Data?.previous.views} accent="border-amber-500" />
-          <MetricCard label="Bounce Rate" value={hasGa4 ? formatBounce(ga4Data!.current.bounceRate) : '\u2014'} current={hasGa4 ? ga4Data!.current.bounceRate * 100 : 0} previous={hasGa4 ? ga4Data!.previous.bounceRate * 100 : 0} accent="border-red-500" icon={Icons.bounce} invert />
-          <MetricCard label="Avg Duration" value={hasGa4 ? formatDuration(ga4Data!.current.avgSessionDuration) : '\u2014'} current={hasGa4 ? ga4Data!.current.avgSessionDuration : 0} previous={hasGa4 ? ga4Data!.previous.avgSessionDuration : 0} accent="border-teal-500" icon={Icons.duration} />
+          <MetricCard icon={Icons.users} label="Users" current={ga4?.current.users ?? 0} previous={ga4?.previous.users} accent="border-blue-500" />
+          <MetricCard icon={Icons.sessions} label="Sessions" current={ga4?.current.sessions ?? 0} previous={ga4?.previous.sessions} accent="border-pink-500" />
+          <MetricCard icon={Icons.views} label="Page Views" current={ga4?.current.views ?? 0} previous={ga4?.previous.views} accent="border-amber-500" />
+          <MetricCard label="Bounce Rate" value={hasGa4 ? formatBounce(ga4!.current.bounceRate) : '\u2014'} current={hasGa4 ? ga4!.current.bounceRate * 100 : 0} previous={hasGa4 ? ga4!.previous.bounceRate * 100 : 0} accent="border-red-500" icon={Icons.bounce} invert />
+          <MetricCard label="Avg Duration" value={hasGa4 ? formatDuration(ga4!.current.avgSessionDuration) : '\u2014'} current={hasGa4 ? ga4!.current.avgSessionDuration : 0} previous={hasGa4 ? ga4!.previous.avgSessionDuration : 0} accent="border-teal-500" icon={Icons.duration} />
         </div>
       </div>
       {(scDaily.length >= 2 || ga4DailyData.length >= 2) && (
@@ -268,11 +277,11 @@ export default async function SiteDashboardPage({
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div>
           <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Top Pages (GA4)</h2>
-          {ga4Data && ga4Data.topPages.length > 0 ? (
+          {ga4 && ga4.topPages.length > 0 ? (
             <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-4">
               <div className="space-y-1.5">
-                {ga4Data.topPages.map((page, i) => {
-                  const maxViews = ga4Data.topPages[0].views || 1;
+                {ga4.topPages.map((page, i) => {
+                  const maxViews = ga4.topPages[0].views || 1;
                   return (
                     <div key={i} className="flex items-center gap-3 text-xs">
                       <span className="text-neutral-400 font-mono truncate min-w-0 flex-1">{page.path}</span>
@@ -291,12 +300,12 @@ export default async function SiteDashboardPage({
         </div>
         <div>
           <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Traffic Sources</h2>
-          {(ga4Data?.trafficSources ?? []).length === 0 ? (
+          {(ga4?.trafficSources ?? []).length === 0 ? (
             <p className="text-neutral-600 text-sm">No traffic source data available.</p>
           ) : (
             <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-4">
               <div className="space-y-1.5">
-                {(ga4Data?.trafficSources ?? []).map((src, i) => (
+                {(ga4?.trafficSources ?? []).map((src, i) => (
                   <div key={i} className="flex items-center justify-between text-xs">
                     <span className="text-neutral-400 font-mono">{formatSource(src.source, src.medium)}</span>
                     <span className="text-neutral-500 font-mono">{pluralize(src.sessions, 'session')}</span>

--- a/app/components/sortable-performance-table.tsx
+++ b/app/components/sortable-performance-table.tsx
@@ -16,8 +16,8 @@ export type PerformanceRow = {
   views: number;
   bounceRate: number | null;   // fraction 0-1
   avgSessionDuration: number | null;  // seconds
-  scClicks: number;
-  scPosition: number;
+  scClicks: number | null;
+  scPosition: number | null;
   hasData: boolean;
 };
 
@@ -160,20 +160,24 @@ export function SortablePerformanceTable({ rows }: { rows: PerformanceRow[] }) {
                   : <span className="text-neutral-600">—</span>}
               </td>
               <td className="px-5 py-3.5 text-right font-mono text-neutral-300">
-                {row.scClicks > 0 ? row.scClicks.toLocaleString() : <span className="text-neutral-600">—</span>}
+                {row.scClicks === null
+                  ? <span className="text-red-400/60 text-xs">error</span>
+                  : row.scClicks > 0 ? row.scClicks.toLocaleString() : <span className="text-neutral-600">—</span>}
               </td>
               <td className="px-5 py-3.5 text-right font-mono hidden md:table-cell">
-                {row.scPosition > 0 ? (
-                  <span className={
-                    row.scPosition <= 3 ? 'text-emerald-400' :
-                    row.scPosition <= 10 ? 'text-amber-400' :
-                    'text-neutral-300'
-                  }>
-                    {row.scPosition}
-                  </span>
-                ) : (
-                  <span className="text-neutral-600">—</span>
-                )}
+                {row.scPosition === null
+                  ? <span className="text-red-400/60 text-xs">error</span>
+                  : row.scPosition > 0 ? (
+                    <span className={
+                      row.scPosition <= 3 ? 'text-emerald-400' :
+                      row.scPosition <= 10 ? 'text-amber-400' :
+                      'text-neutral-300'
+                    }>
+                      {row.scPosition}
+                    </span>
+                  ) : (
+                    <span className="text-neutral-600">—</span>
+                  )}
               </td>
             </tr>
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,20 +17,20 @@ async function getSiteData(days: number) {
 
   const enrichedSites = await Promise.all(
     sites.map(async (site) => {
-      const [scData, ga4Data] = await Promise.all([
+      const [scResult, ga4Result] = await Promise.all([
         site.searchConsole ? cachedGetSearchConsoleData(getSCUrl(site), days) : null,
         cachedGetAnalytics(site.ga4PropertyId || '', days),
       ]);
 
       return {
         ...site,
-        sc: scData || { clicks: 0, impressions: 0, ctr: '0%', position: '0' },
-        ga4: ga4Data,
+        sc: scResult,
+        ga4: ga4Result,
       };
     })
   );
 
-  return enrichedSites.sort((a, b) => (b.ga4?.current.users ?? 0) - (a.ga4?.current.users ?? 0));
+  return enrichedSites.sort((a, b) => (b.ga4?.data?.current.users ?? 0) - (a.ga4?.data?.current.users ?? 0));
 }
 
 export default async function Overview({ searchParams }: { searchParams: Promise<{ days?: string }> }) {
@@ -41,16 +41,18 @@ export default async function Overview({ searchParams }: { searchParams: Promise
 
   const totals = sites.reduce(
     (acc, s) => {
-      if (s.ga4) {
-        acc.users += s.ga4.current.users;
-        acc.sessions += s.ga4.current.sessions;
-        acc.views += s.ga4.current.views;
-        acc.prevUsers += s.ga4.previous.users;
-        acc.prevSessions += s.ga4.previous.sessions;
-        acc.prevViews += s.ga4.previous.views;
+      if (s.ga4?.data) {
+        acc.users += s.ga4.data.current.users;
+        acc.sessions += s.ga4.data.current.sessions;
+        acc.views += s.ga4.data.current.views;
+        acc.prevUsers += s.ga4.data.previous.users;
+        acc.prevSessions += s.ga4.data.previous.sessions;
+        acc.prevViews += s.ga4.data.previous.views;
       }
-      acc.clicks += Number(s.sc.clicks);
-      acc.impressions += Number(s.sc.impressions);
+      if (s.sc?.data) {
+        acc.clicks += Number(s.sc.data.clicks);
+        acc.impressions += Number(s.sc.data.impressions);
+      }
       return acc;
     },
     { users: 0, sessions: 0, views: 0, clicks: 0, impressions: 0, prevUsers: 0, prevSessions: 0, prevViews: 0 }
@@ -60,21 +62,21 @@ export default async function Overview({ searchParams }: { searchParams: Promise
     id: site.id,
     name: site.name,
     domain: site.domain,
-    users: site.ga4?.current.users ?? 0,
-    prevUsers: site.ga4?.previous.users ?? 0,
-    sessions: site.ga4?.current.sessions ?? 0,
-    views: site.ga4?.current.views ?? 0,
-    bounceRate: site.ga4 ? site.ga4.current.bounceRate : null,
-    avgSessionDuration: site.ga4 ? site.ga4.current.avgSessionDuration : null,
-    scClicks: Number(site.sc.clicks),
-    scPosition: Number(site.sc.position),
-    hasData: !!(site.ga4 && site.ga4.current.users > 0),
+    users: site.ga4?.data?.current.users ?? 0,
+    prevUsers: site.ga4?.data?.previous.users ?? 0,
+    sessions: site.ga4?.data?.current.sessions ?? 0,
+    views: site.ga4?.data?.current.views ?? 0,
+    bounceRate: site.ga4?.data ? site.ga4.data.current.bounceRate : null,
+    avgSessionDuration: site.ga4?.data ? site.ga4.data.current.avgSessionDuration : null,
+    scClicks: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.clicks ?? 0),
+    scPosition: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.position ?? 0),
+    hasData: !!(site.ga4?.data && site.ga4.data.current.users > 0),
   }));
 
   const sourceMap = new Map<string, number>();
   for (const site of sites) {
-    if (site.ga4?.trafficSources) {
-      for (const src of site.ga4.trafficSources) {
+    if (site.ga4?.data?.trafficSources) {
+      for (const src of site.ga4.data.trafficSources) {
         const name = formatSource(src.source, src.medium);
         sourceMap.set(name, (sourceMap.get(name) || 0) + src.sessions);
       }

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -194,9 +194,9 @@ function makeSourceRow(source: string, medium: string, sessions: string, users: 
 }
 
 describe('cachedGetAnalytics', () => {
-  it('returns null for empty propertyId', async () => {
+  it('returns no-error result with null data for empty propertyId (not configured)', async () => {
     const result = await cachedGetAnalytics('');
-    expect(result).toBeNull();
+    expect(result).toEqual({ data: null, error: false });
     expect(mockRunReport).not.toHaveBeenCalled();
   });
 
@@ -220,15 +220,16 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([trafficRes]);
 
     const result = await cachedGetAnalytics('12345', 7);
-    expect(result).not.toBeNull();
-    expect(result!.current.users).toBe(100);
-    expect(result!.current.sessions).toBe(80);
-    expect(result!.current.views).toBe(300);
-    expect(result!.current.bounceRate).toBeCloseTo(0.4);
-    expect(result!.current.avgSessionDuration).toBeCloseTo(120.5);
-    expect(result!.topPages).toHaveLength(2);
-    expect(result!.topPages[0]).toEqual({ path: '/home', views: 150, users: 90 });
-    expect(result!.trafficSources[0]).toEqual({ source: 'google', medium: 'organic', sessions: 60, users: 50 });
+    expect(result.error).toBe(false);
+    expect(result.data).not.toBeNull();
+    expect(result.data!.current.users).toBe(100);
+    expect(result.data!.current.sessions).toBe(80);
+    expect(result.data!.current.views).toBe(300);
+    expect(result.data!.current.bounceRate).toBeCloseTo(0.4);
+    expect(result.data!.current.avgSessionDuration).toBeCloseTo(120.5);
+    expect(result.data!.topPages).toHaveLength(2);
+    expect(result.data!.topPages[0]).toEqual({ path: '/home', views: 150, users: 90 });
+    expect(result.data!.trafficSources[0]).toEqual({ source: 'google', medium: 'organic', sessions: 60, users: 50 });
   });
 
   it('parses previous period from second row', async () => {
@@ -244,20 +245,21 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [] }]);
 
     const result = await cachedGetAnalytics('12345', 7);
-    expect(result!.previous.users).toBe(70);
-    expect(result!.previous.sessions).toBe(60);
+    expect(result.data!.previous.users).toBe(70);
+    expect(result.data!.previous.sessions).toBe(60);
   });
 
-  it('returns zeros when metrics rows are empty', async () => {
+  it('returns zeros (not an error) when metrics rows are empty', async () => {
     mockRunReport
       .mockResolvedValueOnce([{ rows: [] }])
       .mockResolvedValueOnce([{ rows: [] }])
       .mockResolvedValueOnce([{ rows: [] }]);
 
     const result = await cachedGetAnalytics('12345');
-    expect(result!.current).toEqual({ users: 0, sessions: 0, views: 0, bounceRate: 0, avgSessionDuration: 0 });
-    expect(result!.topPages).toEqual([]);
-    expect(result!.trafficSources).toEqual([]);
+    expect(result.error).toBe(false);
+    expect(result.data!.current).toEqual({ users: 0, sessions: 0, views: 0, bounceRate: 0, avgSessionDuration: 0 });
+    expect(result.data!.topPages).toEqual([]);
+    expect(result.data!.trafficSources).toEqual([]);
   });
 
   it('skips malformed rows without collapsing current and previous periods', async () => {
@@ -274,21 +276,21 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [] }]);
 
     const result = await cachedGetAnalytics('12345', 7);
-    expect(result!.current).toEqual({
+    expect(result.data!.current).toEqual({
       users: 100,
       sessions: 80,
       views: 300,
       bounceRate: 0.4,
       avgSessionDuration: 120,
     });
-    expect(result!.previous).toEqual({
+    expect(result.data!.previous).toEqual({
       users: 70,
       sessions: 60,
       views: 200,
       bounceRate: 0.5,
       avgSessionDuration: 90,
     });
-    expect(result!.current).not.toEqual(result!.previous);
+    expect(result.data!.current).not.toEqual(result.data!.previous);
   });
 
   it('uses zeroed previous metrics when only one valid metrics row remains', async () => {
@@ -304,14 +306,14 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [] }]);
 
     const result = await cachedGetAnalytics('12345', 7);
-    expect(result!.current).toEqual({
+    expect(result.data!.current).toEqual({
       users: 100,
       sessions: 80,
       views: 300,
       bounceRate: 0.4,
       avgSessionDuration: 120,
     });
-    expect(result!.previous).toEqual({
+    expect(result.data!.previous).toEqual({
       users: 0,
       sessions: 0,
       views: 0,
@@ -320,11 +322,12 @@ describe('cachedGetAnalytics', () => {
     });
   });
 
-  it('returns null on API error', async () => {
+  it('returns error state on API failure, distinct from real zero data', async () => {
     mockRunReport.mockRejectedValue(new Error('Quota exceeded'));
 
     const result = await cachedGetAnalytics('12345');
-    expect(result).toBeNull();
+    expect(result.error).toBe(true);
+    expect(result.data).toBeNull();
   });
 
   it('uses default path for top pages when dimensionValues missing', async () => {
@@ -334,7 +337,7 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [] }]);
 
     const result = await cachedGetAnalytics('12345');
-    expect(result!.topPages[0].path).toBe('/');
+    expect(result.data!.topPages[0].path).toBe('/');
   });
 
   it('uses default source and medium when traffic dimensions are missing', async () => {
@@ -344,7 +347,7 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [{ dimensionValues: [], metricValues: [{ value: '5' }, { value: '3' }] }] }]);
 
     const result = await cachedGetAnalytics('12345');
-    expect(result!.trafficSources[0]).toEqual({
+    expect(result.data!.trafficSources[0]).toEqual({
       source: '(direct)',
       medium: '(none)',
       sessions: 5,
@@ -359,8 +362,8 @@ describe('cachedGetAnalytics', () => {
       .mockResolvedValueOnce([{ rows: [{ dimensionValues: [{ value: 'newsletter' }, { value: 'email' }] }] }]);
 
     const result = await cachedGetAnalytics('12345');
-    expect(result!.topPages[0]).toEqual({ path: '/pricing', views: 0, users: 0 });
-    expect(result!.trafficSources[0]).toEqual({
+    expect(result.data!.topPages[0]).toEqual({ path: '/pricing', views: 0, users: 0 });
+    expect(result.data!.trafficSources[0]).toEqual({
       source: 'newsletter',
       medium: 'email',
       sessions: 0,

--- a/src/lib/__tests__/search-console.test.ts
+++ b/src/lib/__tests__/search-console.test.ts
@@ -127,7 +127,8 @@ describe('cachedGetSearchConsoleData', () => {
     });
 
     const result = await cachedGetSearchConsoleData('example.com', 7);
-    expect(result).toEqual({
+    expect(result.error).toBe(false);
+    expect(result.data).toEqual({
       clicks: 20,
       impressions: 400,
       ctr: '5.00%',
@@ -135,18 +136,20 @@ describe('cachedGetSearchConsoleData', () => {
     });
   });
 
-  it('returns zeros when rows is empty', async () => {
+  it('returns zeros when rows is empty (real zero, not an error)', async () => {
     mockQuery.mockResolvedValue({ data: { rows: [] } });
 
     const result = await cachedGetSearchConsoleData('example.com');
-    expect(result).toEqual({ clicks: 0, impressions: 0, ctr: '0.00%', position: '0.0' });
+    expect(result.error).toBe(false);
+    expect(result.data).toEqual({ clicks: 0, impressions: 0, ctr: '0.00%', position: '0.0' });
   });
 
-  it('returns null on API error', async () => {
+  it('returns error state on API failure', async () => {
     mockQuery.mockRejectedValue(new Error('Network failure'));
 
     const result = await cachedGetSearchConsoleData('example.com');
-    expect(result).toBeNull();
+    expect(result.error).toBe(true);
+    expect(result.data).toBeNull();
   });
 });
 
@@ -165,23 +168,26 @@ describe('cachedGetSearchConsoleDataWithComparison', () => {
       });
 
     const result = await cachedGetSearchConsoleDataWithComparison('example.com', 7);
-    expect(result?.current).toEqual({ clicks: 100, impressions: 2000, ctr: 0.05, position: 3.0 });
-    expect(result?.previous).toEqual({ clicks: 80, impressions: 1600, ctr: 0.05, position: 3.5 });
+    expect(result.error).toBe(false);
+    expect(result.data?.current).toEqual({ clicks: 100, impressions: 2000, ctr: 0.05, position: 3.0 });
+    expect(result.data?.previous).toEqual({ clicks: 80, impressions: 1600, ctr: 0.05, position: 3.5 });
   });
 
-  it('returns zero aggregates when rows are missing', async () => {
+  it('returns zero aggregates (not an error) when rows are missing', async () => {
     mockQuery.mockResolvedValue({ data: {} });
 
     const result = await cachedGetSearchConsoleDataWithComparison('example.com', 7);
-    expect(result?.current).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: 0 });
-    expect(result?.previous).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: 0 });
+    expect(result.error).toBe(false);
+    expect(result.data?.current).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: 0 });
+    expect(result.data?.previous).toEqual({ clicks: 0, impressions: 0, ctr: 0, position: 0 });
   });
 
-  it('returns null on API error', async () => {
+  it('returns error state on API failure', async () => {
     mockQuery.mockRejectedValue(new Error('Auth failed'));
 
     const result = await cachedGetSearchConsoleDataWithComparison('example.com');
-    expect(result).toBeNull();
+    expect(result.error).toBe(true);
+    expect(result.data).toBeNull();
   });
 });
 

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -106,17 +106,23 @@ vi.mock('../../../app/components/keyword-rank-table', () => ({
 vi.mock('@/lib/ga4', () => ({
   discoverPropertyIds: vi.fn(async () => [{ id: 'site-1', ga4PropertyId: 'prop-1' }]),
   cachedGetAnalytics: vi.fn(async () => ({
-    current: { users: 10, sessions: 20, views: 30, bounceRate: 0.45, avgSessionDuration: 12 },
-    previous: { users: 8, sessions: 16, views: 24, bounceRate: 0.4, avgSessionDuration: 10 },
-    topPages: [],
-    sources: [],
+    data: {
+      current: { users: 10, sessions: 20, views: 30, bounceRate: 0.45, avgSessionDuration: 12 },
+      previous: { users: 8, sessions: 16, views: 24, bounceRate: 0.4, avgSessionDuration: 10 },
+      topPages: [],
+      trafficSources: [],
+    },
+    error: false,
   })),
 }));
 
 vi.mock('@/lib/search-console', () => ({
   cachedGetSearchConsoleDataWithComparison: vi.fn(async () => ({
-    current: { clicks: 10, impressions: 100, ctr: 0.1, position: 4.2 },
-    previous: { clicks: 8, impressions: 80, ctr: 0.1, position: 4.8 },
+    data: {
+      current: { clicks: 10, impressions: 100, ctr: 0.1, position: 4.2 },
+      previous: { clicks: 8, impressions: 80, ctr: 0.1, position: 4.8 },
+    },
+    error: false,
   })),
   cachedGetSearchConsoleQueries: vi.fn(async () => []),
   cachedGetSearchConsolePages: vi.fn(async () => []),
@@ -345,5 +351,32 @@ describe('SiteDashboardPage', () => {
     }));
 
     expect(html).toContain('href="/trends#keywords"');
+  });
+
+  it('shows data unavailable indicator on GA4 provider error, not on real zero data', async () => {
+    const { cachedGetAnalytics } = await import('@/lib/ga4');
+    const mockAnalytics = vi.mocked(cachedGetAnalytics);
+
+    mockAnalytics.mockResolvedValueOnce({ data: null, error: true });
+    const errorHtml = renderToStaticMarkup(await SiteDashboardPage({
+      params: Promise.resolve({ site: 'site-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+    expect(errorHtml).toContain('data unavailable');
+
+    mockAnalytics.mockResolvedValueOnce({
+      data: {
+        current: { users: 0, sessions: 0, views: 0, bounceRate: 0, avgSessionDuration: 0 },
+        previous: { users: 0, sessions: 0, views: 0, bounceRate: 0, avgSessionDuration: 0 },
+        topPages: [],
+        trafficSources: [],
+      },
+      error: false,
+    });
+    const zeroHtml = renderToStaticMarkup(await SiteDashboardPage({
+      params: Promise.resolve({ site: 'site-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+    expect(zeroHtml).not.toContain('data unavailable');
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -196,6 +196,8 @@ export function setCache(key: string, siteId: string, data: unknown): void {
   }
 }
 
+export type ProviderResult<T> = { data: T | null; error: boolean };
+
 export async function withCache<T>(
   key: string,
   id: string,

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -2,7 +2,7 @@ import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getManagedSites } from './sites';
-import { clearCacheEntry, withCache } from './db';
+import { clearCacheEntry, withCache, type ProviderResult } from './db';
 
 const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
 const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
@@ -187,7 +187,8 @@ async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Da
   }
 }
 
-export async function cachedGetAnalytics(propertyId: string, days: number = 7): Promise<GA4Data | null> {
-  if (!propertyId) return null;
-  return withCache<GA4Data>(`ga4-${days}`, propertyId, () => getAnalytics(propertyId, days));
+export async function cachedGetAnalytics(propertyId: string, days: number = 7): Promise<ProviderResult<GA4Data>> {
+  if (!propertyId) return { data: null, error: false };
+  const data = await withCache<GA4Data>(`ga4-${days}`, propertyId, () => getAnalytics(propertyId, days));
+  return data !== null ? { data, error: false } : { data: null, error: true };
 }

--- a/src/lib/search-console.ts
+++ b/src/lib/search-console.ts
@@ -1,7 +1,7 @@
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { getAuth } from './google-auth';
 import { daysAgo } from './format';
-import { withCache } from './db';
+import { withCache, type ProviderResult } from './db';
 
 function getSc() {
   return new searchconsole_v1.Searchconsole({ auth: getAuth() });
@@ -209,11 +209,12 @@ export async function cachedGetSitemapSubmissions(siteUrl: string) {
 export async function cachedGetSearchConsoleDataWithComparison(
   siteUrl: string,
   days: number = 7,
-) {
-  return withCache<{ current: SCAggregates; previous: SCAggregates }>(
+): Promise<ProviderResult<{ current: SCAggregates; previous: SCAggregates }>> {
+  const data = await withCache<{ current: SCAggregates; previous: SCAggregates }>(
     `sc-comparison-${days}`, siteUrl,
     () => getSearchConsoleDataWithComparison(siteUrl, days),
   );
+  return data !== null ? { data, error: false } : { data: null, error: true };
 }
 
 export async function cachedGetSearchConsoleQueries(
@@ -239,9 +240,10 @@ export async function cachedGetSearchConsolePages(
 export async function cachedGetSearchConsoleData(
   siteUrl: string,
   days: number = 7,
-) {
-  return withCache<{ clicks: number; impressions: number; ctr: string; position: string }>(
+): Promise<ProviderResult<{ clicks: number; impressions: number; ctr: string; position: string }>> {
+  const data = await withCache<{ clicks: number; impressions: number; ctr: string; position: string }>(
     `sc-data-${days}`, siteUrl,
     () => getSearchConsoleData(siteUrl, days),
   );
+  return data !== null ? { data, error: false } : { data: null, error: true };
 }


### PR DESCRIPTION
Closes #36

**Summary:** Implemented issue #36 — provider failures (SC and GA4 API errors) are now surfaced as explicit error states instead of being coerced to fake zero metrics on the dashboard.

**Files changed:** `src/lib/db.ts`, `src/lib/search-console.ts`, `src/lib/ga4.ts`, `app/page.tsx`, `app/[site]/page.tsx`, `app/components/sortable-performance-table.tsx`, `src/lib/__tests__/search-console.test.ts`, `src/lib/__tests__/ga4.test.ts`, `src/lib/__tests__/trends-page.test.tsx`

**Actionable work:** yes

---
Implemented via TamTam from issue [#36](https://github.com/3h4x/seo-tools/issues/36).