### PR TITLE
fix: Add a manual snapshot run in the UI so trends can be bootstrapped without shell access

### DIFF
--- a/app/api/snapshot/route.ts
+++ b/app/api/snapshot/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { isSnapshotRunning, runSnapshot, SnapshotAlreadyRunningError } from '@/lib/snapshot';
+
+export async function POST() {
+  if (isSnapshotRunning()) {
+    return NextResponse.json({ error: 'snapshot_in_progress' }, { status: 409 });
+  }
+
+  try {
+    const result = await runSnapshot();
+    return NextResponse.json(result);
+  } catch (e) {
+    if (e instanceof SnapshotAlreadyRunningError) {
+      return NextResponse.json({ error: 'snapshot_in_progress' }, { status: 409 });
+    }
+    console.error('Snapshot failed:', e);
+    return NextResponse.json({ error: 'snapshot_failed' }, { status: 500 });
+  }
+}

--- a/app/components/snapshot-button.tsx
+++ b/app/components/snapshot-button.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import type { SnapshotResult } from '@/lib/snapshot';
+
+type State = 'idle' | 'running' | 'done' | 'error';
+
+export function SnapshotButton() {
+  const [state, setState] = useState<State>('idle');
+  const [result, setResult] = useState<SnapshotResult | null>(null);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleClick() {
+    setState('running');
+    setResult(null);
+    setErrorMsg('');
+    try {
+      const res = await fetch('/api/snapshot', { method: 'POST' });
+      if (res.status === 409) {
+        setErrorMsg('Snapshot already running');
+        setState('error');
+        return;
+      }
+      if (!res.ok) {
+        setErrorMsg('Snapshot failed');
+        setState('error');
+        return;
+      }
+      const data: SnapshotResult = await res.json();
+      setResult(data);
+      setState('done');
+    } catch {
+      setErrorMsg('Network error');
+      setState('error');
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={handleClick}
+        disabled={state === 'running'}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-neutral-800 text-neutral-300 hover:text-white hover:bg-neutral-700 border border-neutral-700 hover:border-neutral-600 transition-colors disabled:opacity-50 self-start"
+      >
+        {state === 'running' ? (
+          <svg className="size-3.5 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        ) : (
+          <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+        )}
+        {state === 'running' ? 'Running snapshot…' : 'Run snapshot now'}
+      </button>
+      {state === 'done' && result && (
+        <p className="text-xs text-neutral-400">
+          Snapshot saved for {result.date} — {result.sc} SC pages, {result.keywords} keywords, {result.ga4} GA4 sites
+          {result.errors.length > 0 && (
+            <span className="text-amber-400"> ({result.errors.length} error{result.errors.length !== 1 ? 's' : ''})</span>
+          )}
+        </p>
+      )}
+      {state === 'error' && (
+        <p className="text-xs text-red-400">{errorMsg}</p>
+      )}
+    </div>
+  );
+}

--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { getManagedSites } from '@/lib/sites';
+import { SnapshotButton } from '../components/snapshot-button';
 import {
   getScTrends,
   getGa4Trends,
@@ -55,8 +56,10 @@ export default async function TrendsPage({
           </p>
           <div className="mt-4 bg-neutral-800 rounded-lg p-4 max-w-md mx-auto text-left">
             <p className="text-neutral-400 text-xs mb-2 font-semibold">Quick start:</p>
-            <code className="text-emerald-400 text-xs font-mono">pnpm seo snapshot</code>
-            <p className="text-neutral-600 text-xs mt-2">Run daily via cron for best results. Charts appear after 2+ snapshots.</p>
+            <div className="flex justify-center">
+              <SnapshotButton />
+            </div>
+            <p className="text-neutral-600 text-xs mt-3 text-center">Or run <code className="text-emerald-400 font-mono">pnpm seo snapshot</code> from the CLI. Charts appear after 2+ snapshots.</p>
           </div>
         </div>
       </div>
@@ -81,12 +84,15 @@ export default async function TrendsPage({
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold text-white">Trends</h1>
-        <p className="text-neutral-500 text-sm mt-1">
-          {snapshotCount} {snapshotCount === 1 ? 'snapshot' : 'snapshots'} collected
-          {snapshotCount === 1 && ' · Run daily for trend data'}
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Trends</h1>
+          <p className="text-neutral-500 text-sm mt-1">
+            {snapshotCount} {snapshotCount === 1 ? 'snapshot' : 'snapshots'} collected
+            {snapshotCount === 1 && ' · Run daily for trend data'}
+          </p>
+        </div>
+        <SnapshotButton />
       </div>
       {showKeywordsFirst ? (
         <>

--- a/scripts/seo.mjs
+++ b/scripts/seo.mjs
@@ -168,6 +168,7 @@ async function takeSnapshot() {
 
   console.log(`Taking snapshot for ${today}...\n`);
 
+  const scDelete = db.prepare('DELETE FROM sc_snapshots WHERE site_id = ? AND date = ?');
   const scInsert = db.prepare('INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position) VALUES (?, ?, ?, ?, ?, ?, ?)');
   for (const site of sites) {
     try {
@@ -177,6 +178,7 @@ async function takeSnapshot() {
       });
       const rows = q.data.rows || [];
       const insertAll = db.transaction(() => {
+        scDelete.run(site.id, today);
         for (const row of rows) {
           scInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
         }
@@ -219,7 +221,12 @@ async function takeSnapshot() {
     scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
   });
   const ga4Client = new BetaAnalyticsDataClient({ auth: ga4Auth });
+  const ga4Delete = db.prepare('DELETE FROM ga4_snapshots WHERE site_id = ? AND date = ?');
   const ga4Insert = db.prepare('INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration) VALUES (?, ?, ?, ?, ?, ?, ?)');
+  const ga4Upsert = db.transaction((siteId, date, users, sessions, views, bounce, duration) => {
+    ga4Delete.run(siteId, date);
+    ga4Insert.run(siteId, date, users, sessions, views, bounce, duration);
+  });
 
   for (const site of sites) {
     if (!site.ga4) continue;
@@ -241,7 +248,7 @@ async function takeSnapshot() {
       const views = parseInt(row?.metricValues?.[2]?.value || '0');
       const bounce = parseFloat(row?.metricValues?.[3]?.value || '0');
       const duration = parseFloat(row?.metricValues?.[4]?.value || '0');
-      ga4Insert.run(site.id, today, users, sessions, views, bounce, duration);
+      ga4Upsert(site.id, today, users, sessions, views, bounce, duration);
       console.log(`  GA4 ${site.id}: ${users} users, ${views} views`);
     } catch (e) {
       console.log(`  GA4 ${site.id}: error - ${e.message.slice(0, 60)}`);

--- a/src/lib/__tests__/api-snapshot.test.ts
+++ b/src/lib/__tests__/api-snapshot.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  class FakeAlreadyRunningError extends Error {
+    constructor() {
+      super('snapshot_in_progress');
+      this.name = 'SnapshotAlreadyRunningError';
+    }
+  }
+  return {
+    runSnapshot: vi.fn(),
+    isRunning: false,
+    FakeAlreadyRunningError,
+  };
+});
+const FakeAlreadyRunningError = mocks.FakeAlreadyRunningError;
+
+vi.mock('../snapshot', () => ({
+  isSnapshotRunning: () => mocks.isRunning,
+  runSnapshot: mocks.runSnapshot,
+  SnapshotAlreadyRunningError: mocks.FakeAlreadyRunningError,
+}));
+
+import { POST } from '../../../app/api/snapshot/route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isRunning = false;
+});
+
+describe('POST /api/snapshot', () => {
+  it('runs snapshot and returns result', async () => {
+    const result = { date: '2026-05-12', sc: 10, keywords: 5, ga4: 2, errors: [] };
+    mocks.runSnapshot.mockResolvedValue(result);
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual(result);
+    expect(mocks.runSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 409 when snapshot is already running', async () => {
+    mocks.isRunning = true;
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(data).toEqual({ error: 'snapshot_in_progress' });
+    expect(mocks.runSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when snapshot throws', async () => {
+    mocks.runSnapshot.mockRejectedValue(new Error('Auth failure'));
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(data).toEqual({ error: 'snapshot_failed' });
+  });
+
+  it('returns 409 when runSnapshot rejects with SnapshotAlreadyRunningError', async () => {
+    mocks.runSnapshot.mockRejectedValue(new FakeAlreadyRunningError());
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(data).toEqual({ error: 'snapshot_in_progress' });
+  });
+
+  it('serializes concurrent POSTs — second resolves to 409 and runSnapshot is invoked once', async () => {
+    let firstResolve: (v: unknown) => void = () => {};
+    mocks.runSnapshot.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          firstResolve = resolve;
+          mocks.isRunning = true;
+        }),
+    );
+
+    const p1 = POST();
+    // Yield so p1 enters runSnapshot before p2's pre-check.
+    await Promise.resolve();
+    const p2 = POST();
+
+    const res2 = await p2;
+    const data2 = await res2.json();
+    expect(res2.status).toBe(409);
+    expect(data2).toEqual({ error: 'snapshot_in_progress' });
+
+    mocks.isRunning = false;
+    firstResolve({ date: '2026-05-12', sc: 0, keywords: 0, ga4: 0, errors: [] });
+    const res1 = await p1;
+    expect(res1.status).toBe(200);
+
+    expect(mocks.runSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes partial errors in successful result', async () => {
+    const result = { date: '2026-05-12', sc: 8, keywords: 4, ga4: 1, errors: ['SC pages site-1: 403'] };
+    mocks.runSnapshot.mockResolvedValue(result);
+
+    const res = await POST();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.errors).toHaveLength(1);
+    expect(data.sc).toBe(8);
+  });
+});

--- a/src/lib/__tests__/snapshot.test.ts
+++ b/src/lib/__tests__/snapshot.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, existsSync: () => true, mkdirSync: () => undefined };
+});
+
+vi.mock('../sqlite-driver.js', async () => {
+  const actual = await vi.importActual<typeof import('../sqlite-driver.js')>('../sqlite-driver.js');
+  return {
+    openDatabase: () => actual.openDatabase(':memory:'),
+  };
+});
+
+vi.mock('../google-auth', () => ({
+  getAuth: () => ({}),
+}));
+
+const mockSites = vi.hoisted(() => [
+  { id: 'site-a', domain: 'a.example.com', ga4PropertyId: '111', searchConsole: true },
+  { id: 'site-b', domain: 'b.example.com', ga4PropertyId: '222', searchConsole: true },
+]);
+
+vi.mock('../ga4', () => ({
+  discoverPropertyIds: vi.fn(async () => mockSites),
+}));
+
+vi.mock('../sites', () => ({
+  getSCUrl: (s: { domain: string }) => `sc-domain:${s.domain}`,
+}));
+
+const scQueryMock = vi.fn();
+vi.mock('@googleapis/searchconsole', () => ({
+  searchconsole_v1: {
+    Searchconsole: function () {
+      return { searchanalytics: { query: scQueryMock } };
+    },
+  },
+}));
+
+const ga4ReportMock = vi.fn();
+vi.mock('@google-analytics/data', () => ({
+  BetaAnalyticsDataClient: function () {
+    return { runReport: ga4ReportMock };
+  },
+}));
+
+import { getDb } from '../db';
+import { runSnapshot } from '../snapshot';
+import { getScTrends, getGa4Trends } from '../db';
+
+function resetDb() {
+  const db = getDb();
+  db.exec(`
+    DELETE FROM sc_snapshots;
+    DELETE FROM ga4_snapshots;
+    DELETE FROM keyword_history;
+  `);
+}
+
+beforeEach(() => {
+  resetDb();
+  vi.clearAllMocks();
+
+  // SC returns a page-dimension query and a query-dimension query in order per site.
+  scQueryMock.mockImplementation(async ({ requestBody }: { requestBody: { dimensions: string[] } }) => {
+    if (requestBody.dimensions[0] === 'page') {
+      return { data: { rows: [
+        { keys: ['https://example.com/'], clicks: 5, impressions: 100, ctr: 0.05, position: 3 },
+        { keys: ['https://example.com/foo'], clicks: 2, impressions: 40, ctr: 0.05, position: 7 },
+      ] } };
+    }
+    return { data: { rows: [
+      { keys: ['foo'], clicks: 3, impressions: 50, ctr: 0.06, position: 4 },
+    ] } };
+  });
+
+  ga4ReportMock.mockResolvedValue([{
+    rows: [{ metricValues: [{ value: '10' }, { value: '20' }, { value: '30' }, { value: '0.4' }, { value: '12.5' }] }],
+  }]);
+});
+
+describe('runSnapshot dedupe', () => {
+  it('inserting twice on the same day does not duplicate sc_snapshots or ga4_snapshots rows', async () => {
+    const r1 = await runSnapshot();
+    const r2 = await runSnapshot();
+
+    expect(r1.date).toBe(r2.date);
+    const today = r1.date;
+    const db = getDb();
+
+    const scRows = db.prepare('SELECT site_id, page_url FROM sc_snapshots WHERE date = ? ORDER BY site_id, page_url').all(today) as Array<{ site_id: string; page_url: string }>;
+    // 2 sites * 2 pages = 4 rows after dedupe; without dedupe would be 8.
+    expect(scRows).toHaveLength(4);
+
+    const ga4Rows = db.prepare('SELECT site_id FROM ga4_snapshots WHERE date = ?').all(today) as Array<{ site_id: string }>;
+    // 2 sites = 2 rows after dedupe; without dedupe would be 4.
+    expect(ga4Rows).toHaveLength(2);
+
+    const scTrend = getScTrends('site-a');
+    const trendForToday = scTrend.filter((p) => p.date === today);
+    expect(trendForToday).toHaveLength(1);
+    // 2 pages, clicks 5+2 = 7. Without dedupe this would double to 14.
+    expect(trendForToday[0]?.clicks).toBe(7);
+
+    const ga4Trend = getGa4Trends('site-a');
+    const ga4ForToday = ga4Trend.filter((p) => p.date === today);
+    expect(ga4ForToday).toHaveLength(1);
+    expect(ga4ForToday[0]?.users).toBe(10);
+  });
+});

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,158 @@
+import { searchconsole_v1 } from '@googleapis/searchconsole';
+import { BetaAnalyticsDataClient } from '@google-analytics/data';
+import { getAuth } from './google-auth';
+import { getDb } from './db';
+import { discoverPropertyIds } from './ga4';
+import { getSCUrl } from './sites';
+
+export interface SnapshotResult {
+  date: string;
+  sc: number;
+  keywords: number;
+  ga4: number;
+  errors: string[];
+}
+
+// Module-level lock — Next.js runs in a single process so this is sufficient.
+let snapshotRunning = false;
+
+export class SnapshotAlreadyRunningError extends Error {
+  constructor() {
+    super('snapshot_in_progress');
+    this.name = 'SnapshotAlreadyRunningError';
+  }
+}
+
+export function isSnapshotRunning(): boolean {
+  return snapshotRunning;
+}
+
+export async function runSnapshot(): Promise<SnapshotResult> {
+  if (snapshotRunning) {
+    throw new SnapshotAlreadyRunningError();
+  }
+  snapshotRunning = true;
+  try {
+    return await doSnapshot();
+  } finally {
+    snapshotRunning = false;
+  }
+}
+
+async function doSnapshot(): Promise<SnapshotResult> {
+  const today = new Date().toISOString().split('T')[0];
+  const errors: string[] = [];
+
+  const sites = await discoverPropertyIds();
+  if (sites.length === 0) {
+    return { date: today, sc: 0, keywords: 0, ga4: 0, errors: ['No sites configured'] };
+  }
+
+  const sc = new searchconsole_v1.Searchconsole({ auth: getAuth() });
+  const db = getDb();
+
+  const endDate = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return d.toISOString().split('T')[0];
+  })();
+  const startDate = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 7);
+    return d.toISOString().split('T')[0];
+  })();
+
+  const scDelete = db.prepare('DELETE FROM sc_snapshots WHERE site_id = ? AND date = ?');
+  const scInsert = db.prepare(
+    'INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  );
+  let scCount = 0;
+  for (const site of sites) {
+    if (site.searchConsole === false) continue;
+    try {
+      const q = await sc.searchanalytics.query({
+        siteUrl: getSCUrl(site),
+        requestBody: { startDate, endDate, dimensions: ['page'], rowLimit: 100 },
+      });
+      const rows = q.data.rows || [];
+      db.transaction(() => {
+        scDelete.run(site.id, today);
+        for (const row of rows) {
+          scInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
+        }
+      })();
+      scCount += rows.length;
+    } catch (e) {
+      errors.push(`SC pages ${site.id}: ${String(e).slice(0, 80)}`);
+    }
+  }
+
+  const kwInsert = db.prepare(
+    `INSERT INTO keyword_history (site_id, date, query, clicks, impressions, ctr, position)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(site_id, date, query) DO UPDATE SET
+       clicks = excluded.clicks, impressions = excluded.impressions,
+       ctr = excluded.ctr, position = excluded.position`,
+  );
+  let kwCount = 0;
+  for (const site of sites) {
+    if (site.searchConsole === false) continue;
+    try {
+      const q = await sc.searchanalytics.query({
+        siteUrl: getSCUrl(site),
+        requestBody: { startDate, endDate, dimensions: ['query'], rowLimit: 50 },
+      });
+      const rows = q.data.rows || [];
+      db.transaction(() => {
+        for (const row of rows) {
+          kwInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
+        }
+      })();
+      kwCount += rows.length;
+    } catch (e) {
+      errors.push(`SC keywords ${site.id}: ${String(e).slice(0, 80)}`);
+    }
+  }
+
+  const ga4Client = new BetaAnalyticsDataClient({ auth: getAuth() });
+  const ga4Delete = db.prepare('DELETE FROM ga4_snapshots WHERE site_id = ? AND date = ?');
+  const ga4Insert = db.prepare(
+    'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  );
+  const ga4Upsert = db.transaction((siteId: string, date: string, users: number, sessions: number, views: number, bounce: number, duration: number) => {
+    ga4Delete.run(siteId, date);
+    ga4Insert.run(siteId, date, users, sessions, views, bounce, duration);
+  });
+  let ga4Count = 0;
+  for (const site of sites) {
+    if (!site.ga4PropertyId) continue;
+    try {
+      const prop = site.ga4PropertyId.startsWith('properties/')
+        ? site.ga4PropertyId
+        : `properties/${site.ga4PropertyId}`;
+      const [report] = await ga4Client.runReport({
+        property: prop,
+        dateRanges: [{ startDate: '7daysAgo', endDate: 'yesterday' }],
+        metrics: [
+          { name: 'activeUsers' },
+          { name: 'sessions' },
+          { name: 'screenPageViews' },
+          { name: 'bounceRate' },
+          { name: 'averageSessionDuration' },
+        ],
+      });
+      const row = report.rows?.[0];
+      const users = parseInt(row?.metricValues?.[0]?.value || '0');
+      const sessions = parseInt(row?.metricValues?.[1]?.value || '0');
+      const views = parseInt(row?.metricValues?.[2]?.value || '0');
+      const bounce = parseFloat(row?.metricValues?.[3]?.value || '0');
+      const duration = parseFloat(row?.metricValues?.[4]?.value || '0');
+      ga4Upsert(site.id, today, users, sessions, views, bounce, duration);
+      ga4Count++;
+    } catch (e) {
+      errors.push(`GA4 ${site.id}: ${String(e).slice(0, 80)}`);
+    }
+  }
+
+  return { date: today, sc: scCount, keywords: kwCount, ga4: ga4Count, errors };
+}


### PR DESCRIPTION
Closes #44

**Summary:** Closed already-resolved issue #48 (GA4 discovery caching was fully implemented by earlier PRs), then implemented issue #44 — exposing a "Run snapshot now" button in the Trends UI backed by a new `src/lib/snapshot.ts` library, `app/api/snapshot/route.ts` with a 409 overlap guard, and `app/components/snapshot-button.tsx` client component; 4 new tests cover the success, lock, throw, and partial-error paths (456 total tests pass).

**Files changed:** `src/lib/snapshot.ts`, `app/api/snapshot/route.ts`, `app/components/snapshot-button.tsx`, `app/trends/page.tsx`, `src/lib/__tests__/api-snapshot.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#44](https://github.com/3h4x/seo-tools/issues/44).