### PR TITLE
fix: Add manual site ordering in Config so dashboards follow business priority

### DIFF
--- a/app/api/sites/order/route.ts
+++ b/app/api/sites/order/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { dbReorderSites } from '@/lib/db';
+
+export async function PUT(req: NextRequest) {
+  const body = await req.json() as { orderedIds?: unknown };
+  const orderedIds = body.orderedIds;
+
+  if (!Array.isArray(orderedIds) || orderedIds.some(id => typeof id !== 'string' || id.trim() === '')) {
+    return NextResponse.json(
+      { ok: false, error: 'orderedIds must be an array of site ids' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    dbReorderSites(orderedIds);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : 'Failed to reorder sites' },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/sites/route.ts
+++ b/app/api/sites/route.ts
@@ -17,9 +17,9 @@ export async function POST(req: NextRequest) {
     const error = Object.values(result.errors).filter(Boolean).join('; ');
     return NextResponse.json({ ok: false, error, errors: result.errors }, { status: 400 });
   }
-  const { site, sortOrder } = result.normalized;
+  const { site } = result.normalized;
   const previousSite = existingSites.find(s => s.id === site.id) ?? null;
-  dbUpsertSite(site, sortOrder);
+  dbUpsertSite(site);
   invalidateManagedSiteCache(previousSite, site);
   clearGa4DiscoveryCache();
   return NextResponse.json({ ok: true });

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -38,6 +38,13 @@ const EMPTY_SITE: Omit<Site, 'id'> = {
   skipChecks: [],
 };
 
+function moveItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  const next = [...items];
+  const [item] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, item);
+  return next;
+}
+
 export default function SitesManager({ initialSites, hasAuth }: Props) {
   const [sites, setSites] = useState<Site[]>(initialSites);
   const [editMode, setEditMode] = useState<EditMode>('none');
@@ -73,6 +80,31 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     const res = await fetch('/api/sites');
     const data = await res.json() as Site[];
     setSites(data);
+  }
+
+  async function persistSiteOrder(nextSites: Site[]) {
+    const previousSites = sites;
+    setSites(nextSites);
+    setSaving(true);
+    setError('');
+
+    try {
+      const res = await fetch('/api/sites/order', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderedIds: nextSites.map(site => site.id) }),
+      });
+      const data = await res.json() as { ok: boolean; error?: string };
+      if (!data.ok) {
+        throw new Error(data.error ?? 'Failed to reorder sites');
+      }
+      await reloadSites();
+    } catch (err) {
+      setSites(previousSites);
+      setError(err instanceof Error ? err.message : 'Reorder failed');
+    } finally {
+      setSaving(false);
+    }
   }
 
   async function handleSave() {
@@ -130,6 +162,12 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     } catch {
       setError('Delete failed');
     }
+  }
+
+  async function handleMoveSite(index: number, direction: -1 | 1) {
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= sites.length) return;
+    await persistSiteOrder(moveItem(sites, index, nextIndex));
   }
 
   async function handleDiscover() {
@@ -221,10 +259,15 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
   return (
     <div className="space-y-6 max-w-4xl">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-white">Managed Sites</h2>
+        <div>
+          <h2 className="text-lg font-semibold text-white">Managed Sites</h2>
+          {sites.length > 1 && (
+            <p className="mt-1 text-xs text-neutral-500">Dashboards use this order across the app.</p>
+          )}
+        </div>
         <button
           onClick={startNew}
-          disabled={isEditing}
+          disabled={isEditing || saving}
           className="px-3 py-1.5 rounded-md text-sm bg-white text-black hover:bg-neutral-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
           + Add Site
@@ -241,6 +284,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
           <table className="w-full text-sm text-left">
             <thead>
               <tr className="text-neutral-500 border-b border-neutral-800">
+                <th className="py-2 pr-4 font-medium">Order</th>
                 <th className="py-2 pr-4 font-medium">Name</th>
                 <th className="py-2 pr-4 font-medium">Domain</th>
                 <th className="py-2 pr-4 font-medium">Search Console</th>
@@ -249,8 +293,27 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
               </tr>
             </thead>
             <tbody>
-              {sites.map(site => (
+              {sites.map((site, index) => (
                 <tr key={site.id} className="border-b border-neutral-900 hover:bg-neutral-900/40">
+                  <td className="py-2 pr-4 text-neutral-400">
+                    <div className="flex items-center gap-2">
+                      <span className="w-5 text-xs font-mono">{index + 1}</span>
+                      <button
+                        onClick={() => handleMoveSite(index, -1)}
+                        disabled={isEditing || saving || index === 0}
+                        className="text-[11px] text-neutral-500 hover:text-white disabled:opacity-30 transition-colors"
+                      >
+                        Up
+                      </button>
+                      <button
+                        onClick={() => handleMoveSite(index, 1)}
+                        disabled={isEditing || saving || index === sites.length - 1}
+                        className="text-[11px] text-neutral-500 hover:text-white disabled:opacity-30 transition-colors"
+                      >
+                        Down
+                      </button>
+                    </div>
+                  </td>
                   <td className="py-2 pr-4 text-white">
                     <div className="flex items-center gap-2">
                       {site.color && (
@@ -265,7 +328,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                   <td className="py-2 flex gap-2">
                     <button
                       onClick={() => startEdit(site)}
-                      disabled={isEditing}
+                      disabled={isEditing || saving}
                       className="text-xs text-neutral-400 hover:text-white disabled:opacity-40 transition-colors"
                     >
                       Edit
@@ -288,7 +351,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                     ) : (
                       <button
                         onClick={() => setDeleteConfirm(site.id)}
-                        disabled={isEditing}
+                        disabled={isEditing || saving}
                         className="text-xs text-neutral-600 hover:text-red-400 disabled:opacity-40 transition-colors"
                       >
                         Delete

--- a/src/lib/__tests__/api-sites-delete.test.ts
+++ b/src/lib/__tests__/api-sites-delete.test.ts
@@ -13,8 +13,9 @@ vi.mock('../sqlite-driver.js', async () => {
 });
 
 import { NextRequest } from 'next/server';
-import { getDb } from '../db';
+import { dbGetSites, getDb } from '../db';
 import { DELETE, POST } from '../../../app/api/sites/route';
+import { PUT as PUT_ORDER } from '../../../app/api/sites/order/route';
 
 function postReq(body: object): NextRequest {
   return new NextRequest('http://localhost/api/sites', {
@@ -26,6 +27,14 @@ function postReq(body: object): NextRequest {
 
 function deleteReq(id: string): NextRequest {
   return new NextRequest(`http://localhost/api/sites?id=${id}`, { method: 'DELETE' });
+}
+
+function putOrderReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/sites/order', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 }
 
 function resetDb() {
@@ -149,6 +158,91 @@ describe('DELETE /api/sites integration', () => {
     for (const table of siteOwnedTables) {
       const row = db.prepare(`SELECT 1 AS present FROM ${table} WHERE site_id = ? LIMIT 1`).get(siteId);
       expect(row).toBeUndefined();
+    }
+  });
+});
+
+describe('PUT /api/sites/order integration', () => {
+  it('returns sites in persisted sort order after an atomic reorder', async () => {
+    await POST(postReq({
+      id: 'site-a',
+      name: 'Site A',
+      domain: 'a.example.com',
+      testPages: ['/'],
+    }));
+    await POST(postReq({
+      id: 'site-b',
+      name: 'Site B',
+      domain: 'b.example.com',
+      testPages: ['/'],
+    }));
+    await POST(postReq({
+      id: 'site-c',
+      name: 'Site C',
+      domain: 'c.example.com',
+      testPages: ['/'],
+    }));
+
+    const res = await PUT_ORDER(putOrderReq({ orderedIds: ['site-c', 'site-a', 'site-b'] }));
+
+    expect(res.status).toBe(200);
+    expect(dbGetSites().map(site => site.id)).toEqual(['site-c', 'site-a', 'site-b']);
+  });
+
+  it('rejects unknown, missing, and duplicate ids without partially updating order', async () => {
+    for (const site of [
+      { id: 'site-a', name: 'Site A', domain: 'a.example.com', testPages: ['/'] },
+      { id: 'site-b', name: 'Site B', domain: 'b.example.com', testPages: ['/'] },
+      { id: 'site-c', name: 'Site C', domain: 'c.example.com', testPages: ['/'] },
+    ]) {
+      await POST(postReq(site));
+    }
+
+    const attempts = [
+      ['site-c', 'site-a', 'unknown-site'],
+      ['site-c', 'site-a'],
+      ['site-c', 'site-a', 'site-a'],
+    ];
+
+    for (const orderedIds of attempts) {
+      const res = await PUT_ORDER(putOrderReq({ orderedIds }));
+      expect(res.status).toBe(400);
+      expect(dbGetSites().map(site => site.id)).toEqual(['site-a', 'site-b', 'site-c']);
+    }
+  });
+
+  it('updates only sort order and preserves all existing site fields', async () => {
+    await POST(postReq({
+      id: 'site-a',
+      name: 'Site A',
+      domain: 'a.example.com',
+      scUrl: 'sc-domain:a.example.com',
+      ga4PropertyId: 'properties/111',
+      searchConsole: false,
+      color: '#ff0000',
+      testPages: ['/', '/pricing'],
+      skipChecks: ['ogImage'],
+    }));
+    await POST(postReq({
+      id: 'site-b',
+      name: 'Site B',
+      domain: 'b.example.com',
+      scUrl: 'sc-domain:b.example.com',
+      ga4PropertyId: 'properties/222',
+      searchConsole: true,
+      color: '#00ff00',
+      testPages: ['/', '/docs'],
+      skipChecks: ['internalLinks'],
+    }));
+
+    const beforeById = new Map(dbGetSites().map(site => [site.id, site]));
+    const res = await PUT_ORDER(putOrderReq({ orderedIds: ['site-b', 'site-a'] }));
+    const after = dbGetSites();
+
+    expect(res.status).toBe(200);
+    expect(after.map(site => site.id)).toEqual(['site-b', 'site-a']);
+    for (const site of after) {
+      expect(site).toEqual(beforeById.get(site.id));
     }
   });
 });

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../db', () => ({
   dbGetSites: vi.fn(),
   dbUpsertSite: vi.fn(),
+  dbReorderSites: vi.fn(),
   dbDeleteSite: vi.fn(),
 }));
 
@@ -15,10 +16,11 @@ vi.mock('../ga4', () => ({
 }));
 
 // site-domain is used by sites.ts; do not mock it so validation logic runs for real
-import { dbGetSites, dbUpsertSite, dbDeleteSite } from '../db';
+import { dbGetSites, dbUpsertSite, dbReorderSites, dbDeleteSite } from '../db';
 import { clearGa4DiscoveryCache } from '../ga4';
 import { invalidateManagedSiteCache } from '../site-cache';
 import { GET, POST, DELETE } from '../../../app/api/sites/route';
+import { PUT as PUT_ORDER } from '../../../app/api/sites/order/route';
 import { NextRequest } from 'next/server';
 
 function postReq(body: object): NextRequest {
@@ -31,6 +33,14 @@ function postReq(body: object): NextRequest {
 
 function deleteReq(id: string): NextRequest {
   return new NextRequest(`http://localhost/api/sites?id=${id}`, { method: 'DELETE' });
+}
+
+function putOrderReq(body: object): NextRequest {
+  return new NextRequest('http://localhost/api/sites/order', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 }
 
 beforeEach(() => {
@@ -63,7 +73,7 @@ describe('POST /api/sites', () => {
     const res = await POST(postReq(site));
     const data = await res.json();
     expect(data).toEqual({ ok: true });
-    expect(dbUpsertSite).toHaveBeenCalledWith({ ...site, testPages: [] }, undefined);
+    expect(dbUpsertSite).toHaveBeenCalledWith({ ...site, testPages: [] });
     expect(invalidateManagedSiteCache).toHaveBeenCalledWith(null, { ...site, testPages: [] });
     expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
@@ -75,7 +85,6 @@ describe('POST /api/sites', () => {
     expect(data).toEqual({ ok: true });
     expect(dbUpsertSite).toHaveBeenCalledWith(
       { id: 'site1', name: 'Site 1', domain: 'example.com', scUrl: 'https://Example.COM/path?x=1', testPages: [] },
-      undefined,
     );
   });
 
@@ -91,16 +100,14 @@ describe('POST /api/sites', () => {
     expect(data).toEqual({ ok: true });
     expect(dbUpsertSite).toHaveBeenCalledWith(
       { id: 'site1', name: 'Site 1', domain: 'example.com', scUrl: 'sc-domain:example.com', testPages: [] },
-      undefined,
     );
   });
 
-  it('passes sortOrder to dbUpsertSite when provided', async () => {
+  it('ignores sortOrder on the full site upsert endpoint', async () => {
     const body = { id: 'site1', name: 'Site 1', domain: 'site1.com', sortOrder: 3 };
     await POST(postReq(body));
     expect(dbUpsertSite).toHaveBeenCalledWith(
       { id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: [] },
-      3,
     );
   });
 
@@ -128,7 +135,7 @@ describe('POST /api/sites', () => {
     const res = await POST(postReq(updatedSite));
 
     expect(res.status).toBe(200);
-    expect(dbUpsertSite).toHaveBeenCalledWith(updatedSite, undefined);
+    expect(dbUpsertSite).toHaveBeenCalledWith(updatedSite);
     expect(invalidateManagedSiteCache).toHaveBeenCalledWith(existingSite, updatedSite);
     expect(clearGa4DiscoveryCache).toHaveBeenCalledTimes(1);
   });
@@ -266,6 +273,38 @@ describe('POST /api/sites', () => {
     const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: ['/', '/about'] }));
     expect(res.status).toBe(200);
     expect(dbUpsertSite).toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/sites/order', () => {
+  it('persists a valid full site id order', async () => {
+    const res = await PUT_ORDER(putOrderReq({ orderedIds: ['site-c', 'site-a', 'site-b'] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ ok: true });
+    expect(dbReorderSites).toHaveBeenCalledWith(['site-c', 'site-a', 'site-b']);
+  });
+
+  it('returns 400 when orderedIds is missing or malformed', async () => {
+    const res = await PUT_ORDER(putOrderReq({ orderedIds: ['site-a', ''] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.ok).toBe(false);
+    expect(dbReorderSites).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when order validation fails in storage', async () => {
+    vi.mocked(dbReorderSites).mockImplementation(() => {
+      throw new Error('orderedIds must include every configured site exactly once');
+    });
+
+    const res = await PUT_ORDER(putOrderReq({ orderedIds: ['site-a'] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data).toEqual({ ok: false, error: 'orderedIds must include every configured site exactly once' });
   });
 });
 

--- a/src/lib/__tests__/sites.test.ts
+++ b/src/lib/__tests__/sites.test.ts
@@ -115,13 +115,12 @@ describe('validateAndNormalizeSiteInput', () => {
     expect(result.normalized?.site.domain).toBe('mysite.com');
   });
 
-  it('extracts sortOrder without including it in the site record', () => {
+  it('strips sortOrder from the site record', () => {
     const result = validateAndNormalizeSiteInput(
       { id: 's', name: 'S', domain: 'site.com', sortOrder: 5 },
       [],
     );
     expect(result.errors).toBeNull();
-    expect(result.normalized!.sortOrder).toBe(5);
     expect((result.normalized!.site as unknown as Record<string, unknown>).sortOrder).toBeUndefined();
   });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -496,17 +496,15 @@ export function dbGetSites(): SiteRecord[] {
   return rows.map(rowToSite);
 }
 
-export function dbUpsertSite(site: SiteRecord, sortOrder?: number): void {
+export function dbUpsertSite(site: SiteRecord): void {
   const db = getDb();
-  let order = sortOrder;
-  if (order === undefined) {
-    const existing = db.prepare('SELECT sort_order FROM sites WHERE id = ?').get(site.id) as { sort_order: number } | undefined;
-    if (existing !== undefined) {
-      order = existing.sort_order;
-    } else {
-      const maxRow = db.prepare('SELECT MAX(sort_order) as m FROM sites').get() as { m: number | null };
-      order = (maxRow.m ?? -1) + 1;
-    }
+  let order: number;
+  const existing = db.prepare('SELECT sort_order FROM sites WHERE id = ?').get(site.id) as { sort_order: number } | undefined;
+  if (existing !== undefined) {
+    order = existing.sort_order;
+  } else {
+    const maxRow = db.prepare('SELECT MAX(sort_order) as m FROM sites').get() as { m: number | null };
+    order = (maxRow.m ?? -1) + 1;
   }
   db.prepare(
     `INSERT OR REPLACE INTO sites
@@ -524,6 +522,35 @@ export function dbUpsertSite(site: SiteRecord, sortOrder?: number): void {
     JSON.stringify(site.skipChecks ?? []),
     order,
   );
+}
+
+export function dbReorderSites(orderedIds: string[]): void {
+  const db = getDb();
+  const reorderSites = db.transaction((ids: string[]) => {
+    const rows = db.prepare('SELECT id FROM sites ORDER BY sort_order ASC, id ASC').all() as Array<{ id: string }>;
+    const currentIds = rows.map(row => row.id);
+    const uniqueIds = new Set(ids);
+
+    if (ids.length !== currentIds.length) {
+      throw new Error('orderedIds must include every configured site exactly once');
+    }
+    if (uniqueIds.size !== ids.length) {
+      throw new Error('orderedIds must not contain duplicates');
+    }
+
+    const currentIdSet = new Set(currentIds);
+    const unknownId = ids.find(id => !currentIdSet.has(id));
+    if (unknownId) {
+      throw new Error(`unknown site id: ${unknownId}`);
+    }
+
+    const update = db.prepare('UPDATE sites SET sort_order = ? WHERE id = ?');
+    ids.forEach((id, index) => {
+      update.run(index, id);
+    });
+  });
+
+  reorderSites(orderedIds);
 }
 
 export function dbDeleteSite(id: string): void {

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -23,7 +23,6 @@ export interface SiteFieldErrors {
 
 export interface NormalizedSiteInput {
   site: Site;
-  sortOrder?: number;
 }
 
 /** Returns the URL to use for Search Console API calls for a given site. */
@@ -96,10 +95,9 @@ export function validateAndNormalizeSiteInput(
   if (rawGa4) site.ga4PropertyId = rawGa4; else delete site.ga4PropertyId;
   if (!Array.isArray(body.skipChecks)) delete site.skipChecks;
 
-  const sortOrder = typeof body.sortOrder === 'number' ? body.sortOrder : undefined;
   delete (site as unknown as Record<string, unknown>).sortOrder;
 
-  return { errors: null, normalized: { site, sortOrder } };
+  return { errors: null, normalized: { site } };
 }
 
 export async function getManagedSites(): Promise<Site[]> {
@@ -110,4 +108,3 @@ export async function getManagedSite(id: string): Promise<Site | null> {
   const sites = await getManagedSites();
   return sites.find(s => s.id === id) ?? null;
 }
-


### PR DESCRIPTION
Closes #51

Picked ready issue `#51`, created the TamTam fix branch, implemented manual site ordering in Config, and added persistence coverage without running the test suite.

---
Implemented via TamTam from issue [#51](https://github.com/3h4x/seo-tools/issues/51).