### PR TITLE
fix: Restore dedicated /report and /decay routes so analytics views are deep-linkable

### DIFF
--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -2,31 +2,16 @@ import Link from 'next/link';
 import { cachedAuditAllSites, type CheckStatus, type SiteAuditResult } from '@/lib/audit';
 import { getManagedSites } from '@/lib/sites';
 import { analyzeSiteGaps, type GapSeverity, type GapCategory } from '@/lib/gaps';
-import { detectAllDecay, type DecaySeverity } from '@/lib/decay';
+import { detectAllDecay } from '@/lib/decay';
 import { formatRelativeTime } from '@/lib/format';
 import { statusDots, accentBorder, StatusBadge } from '../components/audit/check-card';
 import { MetricCard } from '../components/metric-card';
 import { CopyButton } from '../components/copy-button';
 import { GapsClient, type SiteGap } from '../components/gaps-client';
-import { DataTable, type DataTableColumn } from '../components/data-table';
 import TimeRange from '../components/time-range';
+import { DecaySection } from '../components/decay-section';
 
 export const revalidate = 300;
-
-const DECAY_SEVERITY_COLORS: Record<DecaySeverity, { badge: string; badgeBg: string }> = {
-  severe: { badge: 'text-red-400', badgeBg: 'bg-red-500/10' },
-  moderate: { badge: 'text-amber-400', badgeBg: 'bg-amber-500/10' },
-  mild: { badge: 'text-blue-400', badgeBg: 'bg-blue-500/10' },
-};
-
-const DECAY_TABLE_COLUMNS: DataTableColumn[] = [
-  { label: 'Site', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-neutral-400 text-xs' },
-  { label: 'Page', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-neutral-300 text-xs truncate max-w-[200px]' },
-  { label: 'Clicks', align: 'right', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-right' },
-  { label: 'Impressions', align: 'right', className: 'px-4 py-3 font-semibold hidden md:table-cell', cellClassName: 'px-4 py-2.5 text-right hidden md:table-cell' },
-  { label: 'Position', align: 'right', className: 'px-4 py-3 font-semibold hidden md:table-cell', cellClassName: 'px-4 py-2.5 text-right hidden md:table-cell' },
-  { label: 'Severity', align: 'right', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-right' },
-];
 
 function worstStatus(audit: SiteAuditResult): CheckStatus {
   const passRate = audit.score.total > 0 ? audit.score.pass / audit.score.total : 0;
@@ -104,10 +89,6 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
   const categoryOrder: GapCategory[] = ['crawlability', 'content', 'social', 'indexing', 'structured-data', 'performance', 'security'];
   const gapCategories = ([...new Set(allSiteGaps.map(sg => sg.gap.category))] as GapCategory[])
     .sort((a, b) => categoryOrder.indexOf(a) - categoryOrder.indexOf(b));
-
-  const allDecaying = decayResults.flatMap(r => r.decayingPages);
-  const severeCount = allDecaying.filter(p => p.severity === 'severe').length;
-  const decaySitesAffected = new Set(allDecaying.map(p => p.siteId)).size;
 
   if (audits.length === 0) {
     return (
@@ -224,67 +205,7 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
           <GapsClient allSiteGaps={allSiteGaps} sites={gapSites} categories={gapCategories} />
         </div>
       )}
-      <div className="space-y-4">
-        <div className="flex items-start justify-between">
-          <div>
-            <h2 className="text-lg font-bold text-white">Content Decay</h2>
-            <p className="text-neutral-500 text-sm mt-1">Pages losing traffic · {period}-day comparison</p>
-          </div>
-          <TimeRange param="period" options={[{ value: '7', label: '7d' }, { value: '30', label: '30d' }]} />
-        </div>
-
-        <div className="grid grid-cols-3 gap-4">
-          <MetricCard label="Decaying Pages" current={allDecaying.length} accent="border-l-red-500" valueColor="text-red-400" />
-          <MetricCard label="Severe" current={severeCount} accent="border-l-amber-500" valueColor="text-amber-400" />
-          <MetricCard label="Sites Affected" current={decaySitesAffected} accent="border-l-blue-500" valueColor="text-blue-400" />
-        </div>
-
-        {allDecaying.length === 0 ? (
-          <div className="bg-neutral-900 rounded-lg border border-neutral-800 border-l-4 border-l-emerald-500 p-8 text-center">
-            <svg className="size-12 mx-auto text-emerald-500 mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-              <polyline points="22 4 12 14.01 9 11.01" />
-            </svg>
-            <p className="text-emerald-400 font-bold text-lg">All clear — no content decay</p>
-            <p className="text-neutral-500 text-sm mt-2 max-w-md mx-auto">
-              Every page across all {decayResults.length} sites is maintaining or growing traffic over the last {period} days.
-            </p>
-          </div>
-        ) : (
-          <DataTable
-            columns={DECAY_TABLE_COLUMNS}
-            rows={allDecaying.map((page) => {
-              let shortPage = page.page;
-              try { shortPage = new URL(page.page).pathname; } catch {}
-              const colors = DECAY_SEVERITY_COLORS[page.severity];
-              return [
-                <span key="site">{page.domain}</span>,
-                <span key="page" title={page.page}>{shortPage}</span>,
-                <span key="clicks">
-                  <span className="text-neutral-300">{page.currentClicks}</span>
-                  <span className="text-red-400 text-[10px] ml-1">{page.clicksDelta}%</span>
-                </span>,
-                <span key="impressions">
-                  <span className="text-neutral-400">{page.currentImpressions}</span>
-                  <span className="text-red-400 text-[10px] ml-1">{page.impressionsDelta}%</span>
-                </span>,
-                <span key="position">
-                  <span className="text-neutral-400">{page.currentPosition.toFixed(1)}</span>
-                  {page.positionDelta > 0 && <span className="text-red-400 text-[10px] ml-1">+{page.positionDelta}</span>}
-                </span>,
-                <span key="severity" className={`${colors.badgeBg} ${colors.badge} inline-flex px-2 py-0.5 rounded-full text-[10px] font-medium uppercase`}>
-                  {page.severity}
-                </span>,
-              ];
-            })}
-            rowKeys={allDecaying.map((page) => `${page.siteId}:${page.page}`)}
-            containerClassName="bg-neutral-900 rounded-lg border border-neutral-800 overflow-hidden"
-            tableClassName="w-full text-sm"
-            headRowClassName="border-b border-neutral-800 text-neutral-500 text-xs uppercase tracking-wider"
-            rowClassName="hover:bg-neutral-800/30 transition-colors"
-          />
-        )}
-      </div>
+      <DecaySection period={period as 7 | 30} decayResults={decayResults} siteCount={managedSites.length} />
     </div>
   );
 }

--- a/app/components/decay-section.tsx
+++ b/app/components/decay-section.tsx
@@ -1,0 +1,136 @@
+import Link from 'next/link';
+import { type ReactNode } from 'react';
+import { type DecaySeverity } from '@/lib/decay';
+import { MetricCard } from './metric-card';
+import TimeRange from './time-range';
+import { DataTable, type DataTableColumn } from './data-table';
+
+type DecayPage = {
+  page: string;
+  siteId: string;
+  domain: string;
+  severity: DecaySeverity;
+  currentClicks: number;
+  previousClicks: number;
+  clicksDelta: number;
+  currentImpressions: number;
+  previousImpressions: number;
+  impressionsDelta: number;
+  currentPosition: number;
+  previousPosition: number;
+  positionDelta: number;
+};
+
+type DecayResult = {
+  siteId: string;
+  domain: string;
+  decayingPages: DecayPage[];
+  totalPages: number;
+};
+
+const DECAY_SEVERITY_COLORS: Record<DecaySeverity, { badge: string; badgeBg: string }> = {
+  severe: { badge: 'text-red-400', badgeBg: 'bg-red-500/10' },
+  moderate: { badge: 'text-amber-400', badgeBg: 'bg-amber-500/10' },
+  mild: { badge: 'text-blue-400', badgeBg: 'bg-blue-500/10' },
+};
+
+const DECAY_TABLE_COLUMNS: DataTableColumn[] = [
+  { label: 'Site', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-neutral-400 text-xs' },
+  { label: 'Page', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-neutral-300 text-xs truncate max-w-[200px]' },
+  { label: 'Clicks', align: 'right', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-right' },
+  { label: 'Impressions', align: 'right', className: 'px-4 py-3 font-semibold hidden md:table-cell', cellClassName: 'px-4 py-2.5 text-right hidden md:table-cell' },
+  { label: 'Position', align: 'right', className: 'px-4 py-3 font-semibold hidden md:table-cell', cellClassName: 'px-4 py-2.5 text-right hidden md:table-cell' },
+  { label: 'Severity', align: 'right', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-right' },
+];
+
+export function DecaySection({
+  period,
+  decayResults,
+  siteCount,
+  title = 'Content Decay',
+  description,
+}: {
+  period: 7 | 30;
+  decayResults: DecayResult[];
+  siteCount: number;
+  title?: string;
+  description?: ReactNode;
+}) {
+  const allDecaying = decayResults.flatMap((result) => result.decayingPages);
+  const severeCount = allDecaying.filter((page) => page.severity === 'severe').length;
+  const decaySitesAffected = new Set(allDecaying.map((page) => page.siteId)).size;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-bold text-white">{title}</h2>
+          <p className="text-neutral-500 text-sm mt-1">
+            {description ?? <>Pages losing traffic · {period}-day comparison</>}
+          </p>
+        </div>
+        <TimeRange param="period" options={[{ value: '7', label: '7d' }, { value: '30', label: '30d' }]} />
+      </div>
+
+      {siteCount === 0 ? (
+        <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-6 text-sm text-neutral-500">
+          No sites configured — <Link href="/config" className="text-white underline">add sites in the Config tab</Link>.
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-4">
+            <MetricCard label="Decaying Pages" current={allDecaying.length} accent="border-l-red-500" valueColor="text-red-400" />
+            <MetricCard label="Severe" current={severeCount} accent="border-l-amber-500" valueColor="text-amber-400" />
+            <MetricCard label="Sites Affected" current={decaySitesAffected} accent="border-l-blue-500" valueColor="text-blue-400" />
+          </div>
+
+          {allDecaying.length === 0 ? (
+            <div className="bg-neutral-900 rounded-lg border border-neutral-800 border-l-4 border-l-emerald-500 p-8 text-center">
+              <svg className="size-12 mx-auto text-emerald-500 mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+              <p className="text-emerald-400 font-bold text-lg">All clear — no content decay</p>
+              <p className="text-neutral-500 text-sm mt-2 max-w-md mx-auto">
+                Every page across all {decayResults.length} sites is maintaining or growing traffic over the last {period} days.
+              </p>
+            </div>
+          ) : (
+            <DataTable
+              columns={DECAY_TABLE_COLUMNS}
+              rows={allDecaying.map((page) => {
+                let shortPage = page.page;
+                try { shortPage = new URL(page.page).pathname; } catch {}
+                const colors = DECAY_SEVERITY_COLORS[page.severity];
+                return [
+                  <span key="site">{page.domain}</span>,
+                  <span key="page" title={page.page}>{shortPage}</span>,
+                  <span key="clicks">
+                    <span className="text-neutral-300">{page.currentClicks}</span>
+                    <span className="text-red-400 text-[10px] ml-1">{page.clicksDelta}%</span>
+                  </span>,
+                  <span key="impressions">
+                    <span className="text-neutral-400">{page.currentImpressions}</span>
+                    <span className="text-red-400 text-[10px] ml-1">{page.impressionsDelta}%</span>
+                  </span>,
+                  <span key="position">
+                    <span className="text-neutral-400">{page.currentPosition.toFixed(1)}</span>
+                    {page.positionDelta > 0 && <span className="text-red-400 text-[10px] ml-1">+{page.positionDelta}</span>}
+                  </span>,
+                  <span key="severity" className={`${colors.badgeBg} ${colors.badge} inline-flex px-2 py-0.5 rounded-full text-[10px] font-medium uppercase`}>
+                    {page.severity}
+                  </span>,
+                ];
+              })}
+              rowKeys={allDecaying.map((page) => `${page.siteId}:${page.page}`)}
+              containerClassName="bg-neutral-900 rounded-lg border border-neutral-800 overflow-hidden"
+              tableClassName="w-full text-sm"
+              headRowClassName="border-b border-neutral-800 text-neutral-500 text-xs uppercase tracking-wider"
+              rowClassName="hover:bg-neutral-800/30 transition-colors"
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/components/nav-links.tsx
+++ b/app/components/nav-links.tsx
@@ -5,7 +5,9 @@ import { usePathname } from 'next/navigation';
 
 const links = [
   { href: '/', label: 'Overview' },
+  { href: '/report', label: 'Report' },
   { href: '/audit', label: 'Audit' },
+  { href: '/decay', label: 'Decay' },
   { href: '/trends', label: 'Trends' },
   { href: '/performance', label: 'Performance' },
   { href: '/config', label: 'Config' },

--- a/app/components/report-page-content.tsx
+++ b/app/components/report-page-content.tsx
@@ -1,0 +1,129 @@
+import Link from 'next/link';
+import { discoverPropertyIds, cachedGetAnalytics } from '@/lib/ga4';
+import { cachedGetSearchConsoleData } from '@/lib/search-console';
+import { getSCUrl } from '@/lib/sites';
+import { formatSource } from '@/lib/format';
+import { MetricCard } from './metric-card';
+import { Icons } from './icons';
+import TimeRange from './time-range';
+import { TrafficSourcesChart } from './overview-charts';
+import DailyTrafficChart from './daily-traffic-chart';
+import { SortablePerformanceTable, type PerformanceRow } from './sortable-performance-table';
+
+async function getSiteData(days: number) {
+  const sites = await discoverPropertyIds();
+
+  const enrichedSites = await Promise.all(
+    sites.map(async (site) => {
+      const [scResult, ga4Result] = await Promise.all([
+        site.searchConsole ? cachedGetSearchConsoleData(getSCUrl(site), days) : null,
+        cachedGetAnalytics(site.ga4PropertyId || '', days),
+      ]);
+
+      return {
+        ...site,
+        sc: scResult,
+        ga4: ga4Result,
+      };
+    }),
+  );
+
+  return enrichedSites.sort((a, b) => (b.ga4?.data?.current.users ?? 0) - (a.ga4?.data?.current.users ?? 0));
+}
+
+export async function ReportPageContent({
+  title,
+  days,
+}: {
+  title: string;
+  days: number;
+}) {
+  const sites = await getSiteData(days);
+
+  if (sites.length === 0) {
+    return (
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-white">{title}</h1>
+        </div>
+        <p className="text-neutral-500 text-sm">
+          No sites configured —{' '}
+          <Link href="/config" className="text-white underline">add sites in the Config tab</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  const totals = sites.reduce(
+    (acc, site) => {
+      if (site.ga4?.data) {
+        acc.users += site.ga4.data.current.users;
+        acc.sessions += site.ga4.data.current.sessions;
+        acc.views += site.ga4.data.current.views;
+        acc.prevUsers += site.ga4.data.previous.users;
+        acc.prevSessions += site.ga4.data.previous.sessions;
+        acc.prevViews += site.ga4.data.previous.views;
+      }
+      if (site.sc?.data) {
+        acc.clicks += Number(site.sc.data.clicks);
+        acc.impressions += Number(site.sc.data.impressions);
+      }
+      return acc;
+    },
+    { users: 0, sessions: 0, views: 0, clicks: 0, impressions: 0, prevUsers: 0, prevSessions: 0, prevViews: 0 },
+  );
+
+  const performanceRows: PerformanceRow[] = sites.map((site) => ({
+    id: site.id,
+    name: site.name,
+    domain: site.domain,
+    users: site.ga4?.data?.current.users ?? 0,
+    prevUsers: site.ga4?.data?.previous.users ?? 0,
+    sessions: site.ga4?.data?.current.sessions ?? 0,
+    views: site.ga4?.data?.current.views ?? 0,
+    bounceRate: site.ga4?.data ? site.ga4.data.current.bounceRate : null,
+    avgSessionDuration: site.ga4?.data ? site.ga4.data.current.avgSessionDuration : null,
+    scClicks: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.clicks ?? 0),
+    scPosition: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.position ?? 0),
+    hasData: !!(site.ga4?.data && site.ga4.data.current.users > 0),
+  }));
+
+  const sourceMap = new Map<string, number>();
+  for (const site of sites) {
+    if (site.ga4?.data?.trafficSources) {
+      for (const source of site.ga4.data.trafficSources) {
+        const name = formatSource(source.source, source.medium);
+        sourceMap.set(name, (sourceMap.get(name) || 0) + source.sessions);
+      }
+    }
+  }
+  const sourceData = [...sourceMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, sessions]) => ({ name, sessions }));
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">{title}</h1>
+          <p className="text-neutral-500 text-sm mt-1">Search Console + GA4 · Last {days} days · {sites.length} sites</p>
+        </div>
+        <TimeRange />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <MetricCard icon={Icons.users} label="Users" current={totals.users} previous={totals.prevUsers} accent="border-blue-500" />
+        <MetricCard icon={Icons.sessions} label="Sessions" current={totals.sessions} previous={totals.prevSessions} accent="border-violet-500" />
+        <MetricCard icon={Icons.views} label="Page Views" current={totals.views} previous={totals.prevViews} accent="border-amber-500" />
+        <MetricCard icon={Icons.clicks} label="SC Clicks" current={totals.clicks} accent="border-emerald-500" />
+        <MetricCard icon={Icons.impressions} label="SC Impressions" current={totals.impressions} accent="border-cyan-500" />
+      </div>
+      <DailyTrafficChart days={days} />
+      <TrafficSourcesChart data={sourceData} />
+      <div>
+        <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Site Performance</h2>
+        <SortablePerformanceTable rows={performanceRows} />
+      </div>
+    </div>
+  );
+}

--- a/app/decay/page.tsx
+++ b/app/decay/page.tsx
@@ -1,0 +1,25 @@
+import { detectAllDecay } from '@/lib/decay';
+import { getManagedSites } from '@/lib/sites';
+import { DecaySection } from '../components/decay-section';
+
+export const revalidate = 300;
+
+export default async function DecayPage({ searchParams }: { searchParams: Promise<{ period?: string }> }) {
+  const params = await searchParams;
+  const period = params.period === '30' ? 30 : 7;
+
+  const [managedSites, decayResults] = await Promise.all([
+    getManagedSites(),
+    detectAllDecay(period as 7 | 30),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Decay</h1>
+        <p className="text-neutral-500 text-sm mt-1">Cross-site traffic losses surfaced outside the audit page</p>
+      </div>
+      <DecaySection period={period as 7 | 30} decayResults={decayResults} siteCount={managedSites.length} />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,114 +1,12 @@
-import { discoverPropertyIds, cachedGetAnalytics } from '@/lib/ga4';
-import { cachedGetSearchConsoleData } from '@/lib/search-console';
-import { getSCUrl } from '@/lib/sites';
-import { formatSource } from '@/lib/format';
 import { VALID_DAYS } from '@/lib/constants';
-import TimeRange from './components/time-range';
-import { MetricCard } from './components/metric-card';
-import { Icons } from './components/icons';
-import { TrafficSourcesChart } from './components/overview-charts';
-import DailyTrafficChart from './components/daily-traffic-chart';
-import { SortablePerformanceTable, type PerformanceRow } from './components/sortable-performance-table';
+import { ReportPageContent } from './components/report-page-content';
 
 export const revalidate = 300;
-
-async function getSiteData(days: number) {
-  const sites = await discoverPropertyIds();
-
-  const enrichedSites = await Promise.all(
-    sites.map(async (site) => {
-      const [scResult, ga4Result] = await Promise.all([
-        site.searchConsole ? cachedGetSearchConsoleData(getSCUrl(site), days) : null,
-        cachedGetAnalytics(site.ga4PropertyId || '', days),
-      ]);
-
-      return {
-        ...site,
-        sc: scResult,
-        ga4: ga4Result,
-      };
-    })
-  );
-
-  return enrichedSites.sort((a, b) => (b.ga4?.data?.current.users ?? 0) - (a.ga4?.data?.current.users ?? 0));
-}
 
 export default async function Overview({ searchParams }: { searchParams: Promise<{ days?: string }> }) {
   const params = await searchParams;
   const rawDays = parseInt(params.days || '7');
   const days = VALID_DAYS.includes(rawDays) ? rawDays : 7;
-  const sites = await getSiteData(days);
 
-  const totals = sites.reduce(
-    (acc, s) => {
-      if (s.ga4?.data) {
-        acc.users += s.ga4.data.current.users;
-        acc.sessions += s.ga4.data.current.sessions;
-        acc.views += s.ga4.data.current.views;
-        acc.prevUsers += s.ga4.data.previous.users;
-        acc.prevSessions += s.ga4.data.previous.sessions;
-        acc.prevViews += s.ga4.data.previous.views;
-      }
-      if (s.sc?.data) {
-        acc.clicks += Number(s.sc.data.clicks);
-        acc.impressions += Number(s.sc.data.impressions);
-      }
-      return acc;
-    },
-    { users: 0, sessions: 0, views: 0, clicks: 0, impressions: 0, prevUsers: 0, prevSessions: 0, prevViews: 0 }
-  );
-
-  const performanceRows: PerformanceRow[] = sites.map((site) => ({
-    id: site.id,
-    name: site.name,
-    domain: site.domain,
-    users: site.ga4?.data?.current.users ?? 0,
-    prevUsers: site.ga4?.data?.previous.users ?? 0,
-    sessions: site.ga4?.data?.current.sessions ?? 0,
-    views: site.ga4?.data?.current.views ?? 0,
-    bounceRate: site.ga4?.data ? site.ga4.data.current.bounceRate : null,
-    avgSessionDuration: site.ga4?.data ? site.ga4.data.current.avgSessionDuration : null,
-    scClicks: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.clicks ?? 0),
-    scPosition: site.sc === null ? 0 : site.sc.error ? null : Number(site.sc.data?.position ?? 0),
-    hasData: !!(site.ga4?.data && site.ga4.data.current.users > 0),
-  }));
-
-  const sourceMap = new Map<string, number>();
-  for (const site of sites) {
-    if (site.ga4?.data?.trafficSources) {
-      for (const src of site.ga4.data.trafficSources) {
-        const name = formatSource(src.source, src.medium);
-        sourceMap.set(name, (sourceMap.get(name) || 0) + src.sessions);
-      }
-    }
-  }
-  const sourceData = [...sourceMap.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-    .map(([name, sessions]) => ({ name, sessions }));
-
-  return (
-    <div className="space-y-8">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white">Overview</h1>
-          <p className="text-neutral-500 text-sm mt-1">Last {days} days · {sites.length} sites</p>
-        </div>
-        <TimeRange />
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-        <MetricCard icon={Icons.users} label="Users" current={totals.users} previous={totals.prevUsers} accent="border-blue-500" />
-        <MetricCard icon={Icons.sessions} label="Sessions" current={totals.sessions} previous={totals.prevSessions} accent="border-violet-500" />
-        <MetricCard icon={Icons.views} label="Page Views" current={totals.views} previous={totals.prevViews} accent="border-amber-500" />
-        <MetricCard icon={Icons.clicks} label="SC Clicks" current={totals.clicks} accent="border-emerald-500" />
-        <MetricCard icon={Icons.impressions} label="SC Impressions" current={totals.impressions} accent="border-cyan-500" />
-      </div>
-      <DailyTrafficChart days={days} />
-      <TrafficSourcesChart data={sourceData} />
-      <div>
-        <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Site Performance</h2>
-        <SortablePerformanceTable rows={performanceRows} />
-      </div>
-    </div>
-  );
+  return ReportPageContent({ title: 'Overview', days });
 }

--- a/app/report/page.tsx
+++ b/app/report/page.tsx
@@ -1,0 +1,12 @@
+import { VALID_DAYS } from '@/lib/constants';
+import { ReportPageContent } from '../components/report-page-content';
+
+export const revalidate = 300;
+
+export default async function ReportPage({ searchParams }: { searchParams: Promise<{ days?: string }> }) {
+  const params = await searchParams;
+  const rawDays = parseInt(params.days || '7');
+  const days = VALID_DAYS.includes(rawDays) ? rawDays : 7;
+
+  return ReportPageContent({ title: 'Report', days });
+}

--- a/src/lib/__tests__/decay-page.test.tsx
+++ b/src/lib/__tests__/decay-page.test.tsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactNode } from 'react';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const {
+  mockDetectAllDecay,
+  mockGetManagedSites,
+} = vi.hoisted(() => ({
+  mockDetectAllDecay: vi.fn(),
+  mockGetManagedSites: vi.fn(),
+}));
+
+vi.mock('@/lib/decay', () => ({
+  detectAllDecay: mockDetectAllDecay,
+}));
+
+vi.mock('@/lib/sites', () => ({
+  getManagedSites: mockGetManagedSites,
+}));
+
+vi.mock('../../../app/components/time-range', () => ({
+  default: () => <div>Time Range</div>,
+}));
+
+vi.mock('../../../app/components/metric-card', () => ({
+  MetricCard: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock('../../../app/components/data-table', () => ({
+  DataTable: () => <div>Data Table</div>,
+}));
+
+import DecayPage from '../../../app/decay/page';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetManagedSites.mockResolvedValue([]);
+  mockDetectAllDecay.mockResolvedValue([]);
+});
+
+describe('Decay page', () => {
+  it('renders the empty state when no sites are configured', async () => {
+    const page = await DecayPage({
+      searchParams: Promise.resolve({ period: '7' }),
+    });
+
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain('Decay');
+    expect(html).toContain('No sites configured');
+    expect(html).toContain('href="/config"');
+  });
+});

--- a/src/lib/__tests__/nav-links.test.tsx
+++ b/src/lib/__tests__/nav-links.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactNode } from 'react';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const {
+  mockUsePathname,
+} = vi.hoisted(() => ({
+  mockUsePathname: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: mockUsePathname,
+}));
+
+import NavLinks from '../../../app/components/nav-links';
+
+describe('NavLinks', () => {
+  it('includes report and decay destinations', () => {
+    mockUsePathname.mockReturnValue('/');
+
+    const html = renderToStaticMarkup(<NavLinks />);
+
+    expect(html).toContain('href="/report"');
+    expect(html).toContain('Report');
+    expect(html).toContain('href="/decay"');
+    expect(html).toContain('Decay');
+  });
+});

--- a/src/lib/__tests__/report-page.test.tsx
+++ b/src/lib/__tests__/report-page.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactNode } from 'react';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const {
+  mockDiscoverPropertyIds,
+} = vi.hoisted(() => ({
+  mockDiscoverPropertyIds: vi.fn(),
+}));
+
+vi.mock('@/lib/ga4', () => ({
+  discoverPropertyIds: mockDiscoverPropertyIds,
+  cachedGetAnalytics: vi.fn(),
+}));
+
+vi.mock('@/lib/search-console', () => ({
+  cachedGetSearchConsoleData: vi.fn(),
+}));
+
+vi.mock('@/lib/sites', () => ({
+  getSCUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/format', () => ({
+  formatSource: (value: string) => value,
+}));
+
+vi.mock('../../../app/components/time-range', () => ({
+  default: () => <div>Time Range</div>,
+}));
+
+vi.mock('../../../app/components/metric-card', () => ({
+  MetricCard: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock('../../../app/components/icons', () => ({
+  Icons: {
+    users: null,
+    sessions: null,
+    views: null,
+    clicks: null,
+    impressions: null,
+  },
+}));
+
+vi.mock('../../../app/components/overview-charts', () => ({
+  TrafficSourcesChart: () => <div>Traffic Sources</div>,
+}));
+
+vi.mock('../../../app/components/daily-traffic-chart', () => ({
+  default: () => <div>Daily Traffic</div>,
+}));
+
+vi.mock('../../../app/components/sortable-performance-table', () => ({
+  SortablePerformanceTable: () => <div>Site Performance</div>,
+}));
+
+import ReportPage from '../../../app/report/page';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDiscoverPropertyIds.mockResolvedValue([]);
+});
+
+describe('Report page', () => {
+  it('renders the empty state when no sites are configured', async () => {
+    const page = await ReportPage({
+      searchParams: Promise.resolve({ days: '7' }),
+    });
+
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain('Report');
+    expect(html).toContain('No sites configured');
+    expect(html).toContain('href="/config"');
+  });
+});


### PR DESCRIPTION
Closes #47

Completed issue #47 by restoring dedicated `/report` and `/decay` routes, reusing existing loaders/sections, and adding route/nav regression tests.

---
Implemented via TamTam from issue [#47](https://github.com/3h4x/seo-tools/issues/47).