### PR TITLE
fix: Surface existing Core Web Vitals data in audit so performance risk is visible alongside SEO checks

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { getManagedSite, getSCUrl } from '@/lib/sites';
+import { getCwvAuditSummary } from '@/lib/performance-site';
 import { discoverPropertyIds, cachedGetAnalytics } from '@/lib/ga4';
 import {
   cachedGetSearchConsoleDataWithComparison,
@@ -14,7 +15,7 @@ import { analyzeSiteGaps } from '@/lib/gaps';
 import { getScDaily, getGa4Daily, getKeywordDeltas } from '@/lib/db';
 import type { KeywordDelta } from '@/lib/keyword-history';
 import { KeywordRankTable } from '../components/keyword-rank-table';
-import { METRIC_COLORS } from '@/lib/constants';
+import { METRIC_COLORS, CWV_RATING_COLORS, CWV_THRESHOLDS, type CwvMetricName } from '@/lib/constants';
 import { pluralize, formatSource, formatDuration, formatBounce } from '@/lib/format';
 import TimeRange from '../components/time-range';
 import { Icons } from '../components/icons';
@@ -82,13 +83,14 @@ export default async function SiteDashboardPage({
 
   const scUrl = getSCUrl(site);
 
-  const [audit, sitemapSubmissions, scComparison, scQueries, scPages, ga4Data] = await Promise.all([
+  const [audit, sitemapSubmissions, scComparison, scQueries, scPages, ga4Data, cwvSummary] = await Promise.all([
     cachedAuditSite(site),
     site.searchConsole ? cachedGetSitemapSubmissions(scUrl) : Promise.resolve([]),
     site.searchConsole ? cachedGetSearchConsoleDataWithComparison(scUrl, days) : null,
     site.searchConsole ? cachedGetSearchConsoleQueries(scUrl, days) : null,
     site.searchConsole ? cachedGetSearchConsolePages(scUrl, days) : null,
     cachedGetAnalytics(propertyId, days),
+    getCwvAuditSummary(siteId),
   ]);
 
   const gapAnalysis = analyzeSiteGaps(audit, site);
@@ -486,6 +488,48 @@ export default async function SiteDashboardPage({
               </div>
             )}
           </CheckCard>
+          {cwvSummary && Object.keys(cwvSummary.metrics).length > 0 && (
+            <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-white font-semibold text-sm">Core Web Vitals</h2>
+                <div className="flex items-center gap-3">
+                  <span className="text-neutral-600 text-[10px] uppercase tracking-wider">
+                    {cwvSummary.source === 'rum' ? 'RUM · GA4' : cwvSummary.source === 'psi-field' ? 'CrUX field' : cwvSummary.source === 'psi-lab' ? 'Lighthouse lab' : ''}
+                  </span>
+                  <Link
+                    href={`/performance/${encodeURIComponent(siteId)}`}
+                    className="text-neutral-500 hover:text-neutral-300 text-xs transition-colors"
+                    onClick={e => e.stopPropagation()}
+                  >
+                    Full detail →
+                  </Link>
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                {(['LCP', 'INP', 'CLS'] as CwvMetricName[]).map(name => {
+                  const metric = cwvSummary.metrics[name];
+                  const t = CWV_THRESHOLDS[name];
+                  if (!metric) {
+                    return (
+                      <div key={name} className="space-y-1">
+                        <div className="text-neutral-600 text-xs font-medium">{name}</div>
+                        <div className="text-neutral-700 text-sm font-mono">—</div>
+                      </div>
+                    );
+                  }
+                  const colors = CWV_RATING_COLORS[metric.rating];
+                  const display = t.unit === 'ms' ? `${Math.round(metric.value)}ms` : metric.value.toFixed(3);
+                  return (
+                    <div key={name} className="space-y-1">
+                      <div className="text-neutral-500 text-xs font-medium">{name}</div>
+                      <div className={`text-lg font-mono font-bold ${colors.text}`}>{display}</div>
+                      <div className={`text-[10px] ${colors.text} opacity-70`}>{colors.label}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           {sections['indexing'] && sections['indexing'].length > 0 && (
             <AuditPanel title="Indexing">
               {sections['indexing'].map(g => <Recommendation key={g.id} gap={g} />)}

--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -4,6 +4,8 @@ import { getManagedSites } from '@/lib/sites';
 import { analyzeSiteGaps, type GapSeverity, type GapCategory } from '@/lib/gaps';
 import { detectAllDecay } from '@/lib/decay';
 import { formatRelativeTime } from '@/lib/format';
+import { getCwvAuditSummary, type CwvAuditSummary } from '@/lib/performance-site';
+import { CWV_RATING_COLORS, CWV_THRESHOLDS, type CwvMetricName } from '@/lib/constants';
 import { statusDots, accentBorder, StatusBadge } from '../components/audit/check-card';
 import { MetricCard } from '../components/metric-card';
 import { CopyButton } from '../components/copy-button';
@@ -53,6 +55,12 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
     getManagedSites(),
     detectAllDecay(period as 7 | 30),
   ]);
+
+  const cwvSummaries = Object.fromEntries(
+    await Promise.all(
+      managedSites.map(async (s) => [s.id, await getCwvAuditSummary(s.id)] as [string, CwvAuditSummary | null])
+    )
+  );
 
   const totalPass = audits.reduce((s, a) => s + a.score.pass, 0);
   const totalWarn = audits.reduce((s, a) => s + a.score.warn, 0);
@@ -149,6 +157,7 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
           const links = checksSummary(audit.internalLinks, { fail: 'no links', warn: 'low links', pass: 'Good linking' });
           const site = managedSites.find(s => s.id === audit.siteId);
           const gapCount = gapCountBySite.get(audit.siteId) ?? 0;
+          const cwv = cwvSummaries[audit.siteId] ?? null;
           return (
             <Link
               key={audit.siteId}
@@ -187,6 +196,25 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
                 <CheckItem label="Int. Links" status={links.status} sublabel={links.label} />
                 <CheckItem label="TTFB" status={audit.ttfb.status} sublabel={audit.ttfb.ms ? `${audit.ttfb.ms}ms` : undefined} />
               </div>
+              {cwv && Object.keys(cwv.metrics).length > 0 && (
+                <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center gap-4 flex-wrap">
+                  <span className="text-neutral-600 text-[10px] uppercase tracking-wider font-medium shrink-0">CWV</span>
+                  {(['LCP', 'INP', 'CLS'] as CwvMetricName[]).map(name => {
+                    const metric = cwv.metrics[name];
+                    if (!metric) return null;
+                    const colors = CWV_RATING_COLORS[metric.rating];
+                    const t = CWV_THRESHOLDS[name];
+                    const display = t.unit === 'ms' ? `${Math.round(metric.value)}ms` : metric.value.toFixed(3);
+                    return (
+                      <div key={name} className="flex items-center gap-1.5">
+                        <span className="text-neutral-500 text-[10px]">{name}</span>
+                        <span className={`text-[10px] font-mono font-semibold ${colors.text}`}>{display}</span>
+                      </div>
+                    );
+                  })}
+                  <span className="text-neutral-700 text-[10px] ml-auto">{cwv.source === 'rum' ? 'RUM' : cwv.source === 'psi-field' ? 'CrUX' : 'Lab'}</span>
+                </div>
+              )}
             </Link>
           );
         })}

--- a/src/lib/__tests__/performance-site.test.ts
+++ b/src/lib/__tests__/performance-site.test.ts
@@ -27,7 +27,7 @@ import {
   cachedGetRumCwvByPage,
   cachedGetRumCwvTrend,
 } from '../performance';
-import { getPerformanceSiteData } from '../performance-site';
+import { getPerformanceSiteData, getCwvAuditSummary } from '../performance-site';
 import { getManagedSite } from '../sites';
 
 const site = {
@@ -142,5 +142,58 @@ describe('getPerformanceSiteData', () => {
       { date: '2026-05-08', metrics: { LCP: { value: 1200, rating: 'good', sampleCount: 2 } } },
       { date: '2026-05-09', metrics: { INP: { value: 180, rating: 'good', sampleCount: 3 } } },
     ]);
+  });
+});
+
+describe('getCwvAuditSummary', () => {
+  it('returns RUM overall metrics when RUM data exists', async () => {
+    vi.mocked(cachedGetRumCoreWebVitals).mockResolvedValueOnce({
+      hasData: true,
+      overall: {
+        LCP: { value: 1500, rating: 'good', sampleCount: 20 },
+        INP: { value: 210, rating: 'ni', sampleCount: 20 },
+        CLS: { value: 0.05, rating: 'good', sampleCount: 20 },
+      },
+      byDevice: { mobile: {}, desktop: {}, tablet: {} },
+    });
+
+    const result = await getCwvAuditSummary('borged-io');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('rum');
+    expect(result!.metrics.LCP).toEqual({ value: 1500, rating: 'good', sampleCount: 20 });
+    expect(result!.metrics.INP).toEqual({ value: 210, rating: 'ni', sampleCount: 20 });
+    expect(vi.mocked(cachedGetRumCwvByPage)).not.toHaveBeenCalled();
+    expect(vi.mocked(cachedGetRumCwvTrend)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to PSI field data when no RUM', async () => {
+    vi.mocked(cachedGetRumCoreWebVitals).mockResolvedValueOnce(null);
+    vi.mocked(cachedGetPagespeed).mockImplementation(async (_url, strategy) => ({
+      url: 'https://borged.io',
+      strategy,
+      performanceScore: null,
+      field: {
+        LCP: { value: 3200, rating: 'poor' },
+        CLS: { value: 0.08, rating: 'good' },
+      },
+      lab: {},
+      fetchedAt: 123,
+    }));
+
+    const result = await getCwvAuditSummary('borged-io');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('psi-field');
+    expect(result!.metrics.LCP).toEqual({ value: 3200, rating: 'poor', sampleCount: 0 });
+    expect(result!.metrics.CLS).toEqual({ value: 0.08, rating: 'good', sampleCount: 0 });
+    expect(vi.mocked(cachedGetPagespeed)).toHaveBeenCalledWith('https://borged.io', 'mobile');
+    expect(vi.mocked(cachedGetPagespeed)).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for unknown site', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(null);
+    const result = await getCwvAuditSummary('nonexistent');
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -133,6 +133,10 @@ vi.mock('@/lib/audit', () => ({
   cachedAuditSite: vi.fn(async () => makeAuditResult()),
 }));
 
+vi.mock('@/lib/performance-site', () => ({
+  getCwvAuditSummary: vi.fn(async () => null),
+}));
+
 vi.mock('@/lib/gaps', () => ({
   analyzeSiteGaps: vi.fn(() => ({
     gaps: [],

--- a/src/lib/performance-site.ts
+++ b/src/lib/performance-site.ts
@@ -182,6 +182,32 @@ export async function getPerformanceSiteData(siteId: string, requestedDays?: num
   };
 }
 
+export interface CwvAuditSummary {
+  metrics: PerformanceMetricMap;
+  source: PerformanceSource;
+}
+
+export async function getCwvAuditSummary(siteId: string): Promise<CwvAuditSummary | null> {
+  const site = await getManagedSite(siteId);
+  if (!site) return null;
+
+  const url = site.domain.startsWith('http') ? site.domain : `https://${site.domain}`;
+  const discovered = await discoverPropertyIds();
+  const propertyId = discovered.find(c => c.id === siteId)?.ga4PropertyId || site.ga4PropertyId || '';
+
+  const [rum, psiMobile] = await Promise.all([
+    propertyId ? cachedGetRumCoreWebVitals(propertyId, 7) : Promise.resolve(null),
+    cachedGetPagespeed(url, 'mobile'),
+  ]);
+
+  if (rum?.hasData) {
+    return { metrics: cloneRumMetrics(rum.overall), source: 'rum' };
+  }
+
+  const fallback = fromPsi(psiMobile);
+  return { metrics: fallback.metrics, source: fallback.source };
+}
+
 export type {
   PerformanceByPageRow,
   PerformanceMetric,


### PR DESCRIPTION
Closes #39

**Summary:** Implemented issue #39 — surfaced existing Core Web Vitals data in the audit UI by adding a lightweight `getCwvAuditSummary()` adapter in `performance-site.ts` that reuses the existing RUM/PSI cached pipeline, then wired it into `/audit` (LCP/INP/CLS badges per site card) and `/[site]` (CWV panel near TTFB with link to `/performance/[site]`).

**Files changed:** `src/lib/performance-site.ts`, `app/audit/page.tsx`, `app/[site]/page.tsx`, `src/lib/__tests__/performance-site.test.ts`, `src/lib/__tests__/trends-page.test.tsx`

**Actionable work:** yes

---
Implemented via TamTam from issue [#39](https://github.com/3h4x/seo-tools/issues/39).