### PR TITLE
fix: Validate canonical URL resolves correctly so dead or redirected canonicals surface during audit

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/search-console';
 import { cachedAuditSite } from '@/lib/audit';
 import { analyzeSiteGaps } from '@/lib/gaps';
+import { summarizeCanonicalChecks } from '@/lib/canonical';
 import { getScDaily, getGa4Daily, getKeywordDeltas } from '@/lib/db';
 import type { KeywordDelta } from '@/lib/keyword-history';
 import { KeywordRankTable } from '../components/keyword-rank-table';
@@ -96,6 +97,7 @@ export default async function SiteDashboardPage({
   const gapAnalysis = analyzeSiteGaps(audit, site);
   const sections = gapsBySection(gapAnalysis.gaps);
   const totalGaps = gapAnalysis.gaps.length;
+  const canonicalSummary = summarizeCanonicalChecks(audit.metaTags);
 
   const sc = scComparison?.data ?? null;
   const scError = scComparison?.error ?? false;
@@ -394,6 +396,27 @@ export default async function SiteDashboardPage({
             </div>
             {sections['metaTags']?.map(g => <Recommendation key={g.id} gap={g} />)}
           </AuditPanel>
+          <CheckCard check={canonicalSummary}>
+            <div className="mt-3 space-y-2">
+              {audit.metaTags.map((meta, i) => (
+                <div key={i} className="flex items-start gap-3 text-xs">
+                  <div className={`size-1.5 rounded-full shrink-0 mt-1 ${statusDots[meta.canonical.status]}`} />
+                  <div className="min-w-0">
+                    <div className="text-neutral-300 font-mono">{meta.page}</div>
+                    <div className={meta.canonical.status === 'fail' ? 'text-red-400' : meta.canonical.status === 'warn' ? 'text-amber-400' : 'text-neutral-500'}>
+                      {meta.canonical.message}
+                    </div>
+                    {meta.canonicalTarget && (
+                      <div className="text-neutral-600 font-mono break-all">
+                        {meta.canonicalTarget}
+                        {meta.canonicalStatus ? ` · HTTP ${meta.canonicalStatus}` : ''}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CheckCard>
           <CheckCard check={audit.ogImage} gaps={sections['ogImage']}>
             {audit.ogImage.url && (
               <div className="mt-3 space-y-3">

--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { cachedAuditAllSites, type CheckStatus, type SiteAuditResult } from '@/lib/audit';
+import { summarizeCanonicalChecks } from '@/lib/canonical';
 import { getManagedSites } from '@/lib/sites';
 import { analyzeSiteGaps, type GapSeverity, type GapCategory } from '@/lib/gaps';
 import { detectAllDecay, type DecaySeverity } from '@/lib/decay';
@@ -172,6 +173,7 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
         {audits.map((audit) => {
           const worst = worstStatus(audit);
           const meta = metaTagsSummary(audit);
+          const canonical = summarizeCanonicalChecks(audit.metaTags);
           const images = checksSummary(audit.imageSeo, { fail: 'missing alt', warn: 'need alt', pass: 'All images have alt' });
           const links = checksSummary(audit.internalLinks, { fail: 'no links', warn: 'low links', pass: 'Good linking' });
           const site = managedSites.find(s => s.id === audit.siteId);
@@ -204,12 +206,13 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-9 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-10 gap-3">
                 <CheckItem label="robots.txt" status={audit.robotsTxt.status} />
                 <CheckItem label="Sitemap" status={audit.sitemap.status} />
                 <CheckItem label="SC Sitemap" status={audit.scSitemapFreshness.status} />
                 <CheckItem label="Indexing" status={audit.indexingCoverage.status} sublabel={audit.indexingCoverage.coveragePct != null ? `${audit.indexingCoverage.coveragePct}%` : undefined} />
                 <CheckItem label="Meta Tags" status={meta.status} sublabel={meta.label} />
+                <CheckItem label="Canonical" status={canonical.status} sublabel={canonical.compactLabel} />
                 <CheckItem label="OG Image" status={audit.ogImage.status} />
                 <CheckItem label="Images" status={images.status} sublabel={images.label} />
                 <CheckItem label="Int. Links" status={links.status} sublabel={links.label} />

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { applyImportResults, buildImportSummary, getImportResult, type DiscoverySite, type ImportResult, type ImportSummary } from '@/lib/discovery-import';
 import { getSiteScUrlOverride, isValidSiteDomain, isValidSiteId, normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
+import { SKIP_CHECK_OPTIONS, hasSkipCheck, toggleSkipCheck } from '@/lib/skip-checks';
 
 interface Site {
   id: string;
@@ -453,18 +454,15 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
             <div className="space-y-1 col-span-2">
               <label className="text-xs text-neutral-400">Skip checks</label>
               <div className="grid grid-cols-3 gap-x-4 gap-y-1.5 pt-1">
-                {['robots.txt','Sitemap','SC Sitemap','Indexing','title','description','og:title','og:description','og:image','OG Image','twitter:card','canonical','JSON-LD','HTTPS','HSTS','Favicon','TTFB','Images','Internal Links'].map(label => (
-                  <label key={label} className="flex items-center gap-2 cursor-pointer">
+                {SKIP_CHECK_OPTIONS.map(({ id, label }) => (
+                  <label key={id} className="flex items-center gap-2 cursor-pointer">
                     <input
                       type="checkbox"
-                      checked={(form.skipChecks ?? []).map(s => s.toLowerCase()).includes(label.toLowerCase())}
+                      checked={hasSkipCheck(form.skipChecks, id)}
                       onChange={e => setForm(f => {
-                        const current = f.skipChecks ?? [];
                         return {
                           ...f,
-                          skipChecks: e.target.checked
-                            ? [...current, label]
-                            : current.filter(s => s.toLowerCase() !== label.toLowerCase()),
+                          skipChecks: toggleSkipCheck(f.skipChecks, id, e.target.checked),
                         };
                       })}
                       className="rounded border-neutral-600"

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -259,6 +259,24 @@ describe('POST /api/sites', () => {
     expect(dbUpsertSite).toHaveBeenCalled();
   });
 
+  it('normalizes skipChecks to stable ids before upsert', async () => {
+    const res = await POST(postReq({
+      id: 'site1',
+      name: 'Site 1',
+      domain: 'site1.com',
+      skipChecks: ['OG Image', 'Internal Links', 'og:image'],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalledWith({
+      id: 'site1',
+      name: 'Site 1',
+      domain: 'site1.com',
+      testPages: [],
+      skipChecks: ['ogImage', 'internalLinks', 'ogImageMeta'],
+    });
+  });
+
   it('returns 400 when a testPage entry does not start with /', async () => {
     const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: ['noslash'] }));
     expect(res.status).toBe(400);

--- a/src/lib/__tests__/audit-async.test.ts
+++ b/src/lib/__tests__/audit-async.test.ts
@@ -322,6 +322,203 @@ describe('auditSite — skipChecks', () => {
     expect(result.security.favicon.status).toBe('pass');
     expect(result.security.favicon.message).toContain('N/A');
   });
+
+  it('marks skipped canonical checks as pass with N/A prefix', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        const u = String(url);
+        if (opts?.method === 'HEAD' && u === 'https://example.com/') {
+          return Promise.resolve(new Response('', { status: 404 }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite({ skipChecks: ['canonical'] }));
+    expect(result.metaTags[0].canonical.status).toBe('pass');
+    expect(result.metaTags[0].canonical.message).toContain('N/A');
+  });
+
+  it('matches identifier-style skip keys for OG image and internal links', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        const u = String(url);
+        if (u.endsWith('/favicon.ico')) {
+          return makeResponse({ status: 404, body: 'missing' });
+        }
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+        }
+        return makeResponse({
+          body: '<html><head><title>Test</title></head><body><img src="/hero.jpg"><a href="/about">About</a></body></html>',
+        });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite({ skipChecks: ['ogImage', 'internalLinks'] }));
+    expect(result.ogImage.status).toBe('pass');
+    expect(result.ogImage.message).toContain('N/A');
+    expect(result.internalLinks[0].status).toBe('pass');
+    expect(result.internalLinks[0].message).toContain('N/A');
+  });
+
+  it('keeps og:image meta skips separate from the OG Image asset check', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        const u = String(url);
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+        }
+        return makeResponse({
+          body: '<html><head><title>Test</title><meta property="og:image" content="https://example.com/og.png"></head><body></body></html>',
+        });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite({ skipChecks: ['ogImage'] }));
+    expect(result.ogImage.status).toBe('pass');
+    expect(result.ogImage.message).toContain('N/A');
+    expect(result.metaTags[0].ogImage.status).toBe('pass');
+    expect(result.metaTags[0].ogImage.message).not.toContain('N/A');
+  });
+});
+
+describe('auditSite — canonical', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSitemapsList.mockResolvedValue({ data: { sitemap: [] } });
+    mockSearchAnalyticsQuery.mockResolvedValue({ data: { rows: [] } });
+  });
+
+  it('skips the HEAD validation when canonical is missing', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => makeResponse({ body: '<html><head><title>Test</title></head></html>' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('fail');
+    expect(result.metaTags[0].canonicalStatus).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalledWith('https://example.com/', expect.objectContaining({ method: 'HEAD' }));
+  });
+
+  it('passes when canonical is self-referential and returns 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        if (opts?.method === 'HEAD') {
+          return Promise.resolve(new Response('', { status: 200 }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('pass');
+    expect(result.metaTags[0].canonicalValid).toBe(true);
+    expect(result.metaTags[0].canonicalStatus).toBe(200);
+    expect(result.metaTags[0].canonicalTarget).toBe('https://example.com/');
+  });
+
+  it('warns when canonical returns a redirect', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        if (opts?.method === 'HEAD') {
+          return Promise.resolve(new Response('', { status: 301, headers: { location: 'https://example.com/final' } }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('warn');
+    expect(result.metaTags[0].canonicalStatus).toBe(301);
+    expect(result.metaTags[0].canonical.message).toContain('redirects');
+  });
+
+  it('fails when canonical returns 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        if (opts?.method === 'HEAD') {
+          return Promise.resolve(new Response('', { status: 404 }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('fail');
+    expect(result.metaTags[0].canonicalValid).toBe(false);
+    expect(result.metaTags[0].canonicalStatus).toBe(404);
+  });
+
+  it('warns when canonical points to a different page', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        if (opts?.method === 'HEAD') {
+          return Promise.resolve(new Response('', { status: 200 }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/other"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('warn');
+    expect(result.metaTags[0].canonicalValid).toBe(false);
+    expect(result.metaTags[0].canonicalTarget).toBe('https://example.com/other');
+    expect(result.metaTags[0].canonical.message).toContain('different URL');
+  });
+
+  it('falls back to GET when HEAD is not supported', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'HEAD') {
+        return Promise.resolve(new Response('', { status: 405 }));
+      }
+      if (opts?.method === 'GET') {
+        return Promise.resolve(new Response('<html></html>', { status: 200 }));
+      }
+      return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('pass');
+    expect(result.metaTags[0].canonicalStatus).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('fails when HEAD is unsupported and GET also fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { method?: string }) => {
+        if (opts?.method === 'HEAD') {
+          return Promise.resolve(new Response('', { status: 501 }));
+        }
+        if (opts?.method === 'GET') {
+          return Promise.resolve(new Response('missing', { status: 404 }));
+        }
+        return makeResponse({ body: '<html><head><title>Test</title><link rel="canonical" href="https://example.com/"></head></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.metaTags[0].canonical.status).toBe('fail');
+    expect(result.metaTags[0].canonicalStatus).toBe(404);
+    expect(result.metaTags[0].canonical.message).toContain('HTTP 404');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/canonical.test.ts
+++ b/src/lib/__tests__/canonical.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { getBrokenCanonicalPages, getMissingCanonicalPages, summarizeCanonicalChecks } from '../canonical';
+
+function makeMetaTag(
+  overrides: Partial<{
+    page: string;
+    canonicalStatus: 'pass' | 'warn' | 'fail' | 'error';
+    canonicalMessage: string;
+    canonicalTarget: string | null;
+    canonicalValid: boolean | null;
+    canonicalHttpStatus: number | null;
+  }> = {},
+) {
+  return {
+    page: overrides.page ?? '/',
+    ogImageUrl: undefined,
+    canonicalValid: overrides.canonicalValid ?? null,
+    canonicalStatus: overrides.canonicalHttpStatus ?? null,
+    canonicalTarget: overrides.canonicalTarget ?? null,
+    title: { status: 'pass' as const, label: 'title', message: 'ok' },
+    description: { status: 'pass' as const, label: 'description', message: 'ok' },
+    ogTitle: { status: 'pass' as const, label: 'og:title', message: 'ok' },
+    ogImage: { status: 'pass' as const, label: 'og:image', message: 'ok' },
+    ogDescription: { status: 'pass' as const, label: 'og:description', message: 'ok' },
+    twitterCard: { status: 'pass' as const, label: 'twitter:card', message: 'ok' },
+    canonical: {
+      status: overrides.canonicalStatus ?? 'pass',
+      label: 'canonical',
+      message: overrides.canonicalMessage ?? 'Self-referential canonical resolves',
+    },
+    jsonLd: { status: 'pass' as const, label: 'JSON-LD', message: 'ok' },
+  };
+}
+
+describe('canonical helpers', () => {
+  it('surfaces skipped canonical checks as skipped instead of successful validation', () => {
+    const summary = summarizeCanonicalChecks([
+      makeMetaTag({ canonicalStatus: 'pass', canonicalMessage: 'N/A — Self-referential canonical resolves' }),
+    ]);
+
+    expect(summary.status).toBe('pass');
+    expect(summary.compactLabel).toBe('1 skipped');
+    expect(summary.message).toContain('skipped (N/A)');
+  });
+
+  it('shows mixed pass and skipped canonical checks without claiming all passed', () => {
+    const summary = summarizeCanonicalChecks([
+      makeMetaTag({ canonicalTarget: 'https://example.com/' }),
+      makeMetaTag({ page: '/docs', canonicalStatus: 'pass', canonicalMessage: 'N/A — Self-referential canonical resolves' }),
+    ]);
+
+    expect(summary.compactLabel).toBe('1/2 pass, 1 skipped');
+    expect(summary.message).toContain('1 skipped');
+  });
+
+  it('separates missing canonical tags from broken canonical targets', () => {
+    const metaTags = [
+      makeMetaTag({ page: '/', canonicalStatus: 'fail', canonicalMessage: 'Not found', canonicalTarget: null }),
+      makeMetaTag({
+        page: '/pricing',
+        canonicalStatus: 'fail',
+        canonicalMessage: 'Canonical returns HTTP 404',
+        canonicalTarget: 'https://example.com/pricing',
+        canonicalValid: false,
+        canonicalHttpStatus: 404,
+      }),
+    ];
+
+    expect(getMissingCanonicalPages(metaTags).map((meta) => meta.page)).toEqual(['/']);
+    expect(getBrokenCanonicalPages(metaTags).map((meta) => meta.page)).toEqual(['/pricing']);
+  });
+
+  it('describes missing canonicals without calling them broken targets', () => {
+    const summary = summarizeCanonicalChecks([
+      makeMetaTag({ canonicalStatus: 'fail', canonicalMessage: 'Not found', canonicalTarget: null }),
+    ]);
+
+    expect(summary.status).toBe('fail');
+    expect(summary.message).toBe('1 page missing canonical tags');
+    expect(summary.message).not.toContain('failing canonical targets');
+  });
+
+  it('uses a neutral issues summary when missing and broken canonicals are mixed', () => {
+    const summary = summarizeCanonicalChecks([
+      makeMetaTag({ canonicalStatus: 'fail', canonicalMessage: 'Not found', canonicalTarget: null }),
+      makeMetaTag({
+        page: '/pricing',
+        canonicalStatus: 'fail',
+        canonicalMessage: 'Canonical returns HTTP 404',
+        canonicalTarget: 'https://example.com/pricing',
+        canonicalValid: false,
+        canonicalHttpStatus: 404,
+      }),
+    ]);
+
+    expect(summary.status).toBe('fail');
+    expect(summary.compactLabel).toBe('2 issues');
+    expect(summary.message).toContain('2 pages have canonical issues');
+    expect(summary.message).toContain('1 missing, 1 broken targets');
+  });
+});

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -10,6 +10,9 @@ function makeCheckResult(status: 'pass' | 'warn' | 'fail' | 'error', label: stri
 function makeMetaTagResult(page: string, overrides: Record<string, ReturnType<typeof makeCheckResult>> = {}) {
   return {
     page,
+    canonicalValid: null,
+    canonicalStatus: null,
+    canonicalTarget: null,
     title: makeCheckResult('pass', 'title'),
     description: makeCheckResult('pass', 'description'),
     ogTitle: makeCheckResult('pass', 'og:title'),
@@ -143,6 +146,23 @@ describe('analyzeSiteGaps', () => {
     const gap = result.gaps.find(g => g.id === 'missing-canonical');
     expect(gap).toBeDefined();
     expect(gap?.severity).toBe('high');
+  });
+
+  it('includes broken-canonical-targets gap for pages with failing canonical targets', () => {
+    const audit = makeAudit({
+      metaTags: [{
+        ...makeMetaTagResult('/', { canonical: makeCheckResult('fail', 'canonical') }),
+        canonicalTarget: 'https://example.com/broken',
+        canonicalValid: false,
+        canonicalStatus: 404,
+      }],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    expect(result.gaps.find((gap) => gap.id === 'missing-canonical')).toBeUndefined();
+    const gap = result.gaps.find((g) => g.id === 'broken-canonical-targets');
+    expect(gap).toBeDefined();
+    expect(gap?.severity).toBe('high');
+    expect(gap?.affectedPages).toContain('/');
   });
 
   it('includes missing-twitter-card gap for pages without twitter:card', () => {

--- a/src/lib/__tests__/sites.test.ts
+++ b/src/lib/__tests__/sites.test.ts
@@ -213,4 +213,22 @@ describe('validateAndNormalizeSiteInput', () => {
     expect(result.errors).toBeNull();
     expect(result.normalized?.site.testPages).toEqual(['/', '/about']);
   });
+
+  it('normalizes skipChecks to stable ids before storage', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', skipChecks: ['OG Image', 'Internal Links', 'og:image'] },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.skipChecks).toEqual(['ogImage', 'internalLinks', 'ogImageMeta']);
+  });
+
+  it('preserves existing identifier-style skipChecks when a site is re-saved', () => {
+    const result = validateAndNormalizeSiteInput(
+      { id: 's', name: 'S', domain: 'site.com', skipChecks: ['ogImage', 'internalLinks'] },
+      [],
+    );
+    expect(result.errors).toBeNull();
+    expect(result.normalized?.site.skipChecks).toEqual(['ogImage', 'internalLinks']);
+  });
 });

--- a/src/lib/__tests__/skip-checks.test.ts
+++ b/src/lib/__tests__/skip-checks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SKIP_CHECK_OPTIONS,
+  getSkipCheckId,
+  hasSkipCheck,
+  normalizeSkipChecks,
+  toggleSkipCheck,
+} from '../skip-checks';
+
+describe('skip-check helpers', () => {
+  it('exposes stable ids for the Config UI options', () => {
+    expect(SKIP_CHECK_OPTIONS.find((option) => option.id === 'ogImage')?.label).toBe('OG Image');
+    expect(SKIP_CHECK_OPTIONS.find((option) => option.id === 'ogImageMeta')?.label).toBe('og:image');
+  });
+
+  it('normalizes legacy labels and identifier-style keys to canonical ids', () => {
+    expect(normalizeSkipChecks(['OG Image', 'Internal Links', 'canonical'])).toEqual([
+      'ogImage',
+      'internalLinks',
+      'canonical',
+    ]);
+    expect(normalizeSkipChecks(['ogImage', 'internalLinks', 'jsonLd'])).toEqual([
+      'ogImage',
+      'internalLinks',
+      'jsonLd',
+    ]);
+  });
+
+  it('keeps og:image distinct from the OG Image asset check', () => {
+    expect(getSkipCheckId('og:image')).toBe('ogImageMeta');
+    expect(getSkipCheckId('ogImage')).toBe('ogImage');
+    expect(normalizeSkipChecks(['og:image', 'ogImage'])).toEqual(['ogImageMeta', 'ogImage']);
+  });
+
+  it('treats existing identifier-style keys as selected in the UI helper path', () => {
+    const current = ['ogImage', 'internalLinks'];
+    expect(hasSkipCheck(current, 'ogImage')).toBe(true);
+    expect(hasSkipCheck(current, 'internalLinks')).toBe(true);
+    expect(hasSkipCheck(current, 'canonical')).toBe(false);
+  });
+
+  it('preserves canonical ids when toggling checkboxes for save payloads', () => {
+    const current = ['ogImage', 'internalLinks'];
+    expect(toggleSkipCheck(current, 'internalLinks', true)).toEqual(['ogImage', 'internalLinks']);
+    expect(toggleSkipCheck(current, 'canonical', true)).toEqual(['ogImage', 'internalLinks', 'canonical']);
+    expect(toggleSkipCheck(current, 'ogImage', false)).toEqual(['internalLinks']);
+  });
+});

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -168,7 +168,13 @@ vi.mock('../../../app/components/metric-card', () => ({
 }));
 
 vi.mock('../../../app/components/audit/check-card', () => ({
-  CheckCard: () => <div>Check Card</div>,
+  CheckCard: ({ check, children }: { check: { label: string; message: string }; children?: React.ReactNode }) => (
+    <div>
+      <div>{check.label}</div>
+      <div>{check.message}</div>
+      {children}
+    </div>
+  ),
   statusDots: {},
   Recommendation: () => <div>Recommendation</div>,
   MetaChecksTable: () => <div>Meta Checks</div>,
@@ -382,5 +388,63 @@ describe('SiteDashboardPage', () => {
       searchParams: Promise.resolve({}),
     }));
     expect(zeroHtml).not.toContain('data unavailable');
+  });
+
+  it('shows skipped canonical checks as N/A instead of valid self-referential canonicals', async () => {
+    const { cachedAuditSite } = await import('@/lib/audit');
+    vi.mocked(cachedAuditSite).mockResolvedValueOnce({
+      ...makeAuditResult(),
+      metaTags: [{
+        page: '/',
+        canonicalValid: true,
+        canonicalStatus: 200,
+        canonicalTarget: 'https://site-one.test/',
+        title: makeCheckResult({ label: 'title' }),
+        description: makeCheckResult({ label: 'description' }),
+        ogTitle: makeCheckResult({ label: 'og:title' }),
+        ogImage: makeCheckResult({ label: 'og:image' }),
+        ogDescription: makeCheckResult({ label: 'og:description' }),
+        twitterCard: makeCheckResult({ label: 'twitter:card' }),
+        canonical: makeCheckResult({ label: 'canonical', message: 'N/A — Self-referential canonical resolves' }),
+        jsonLd: makeCheckResult({ label: 'JSON-LD' }),
+      }],
+    });
+
+    const html = renderToStaticMarkup(await SiteDashboardPage({
+      params: Promise.resolve({ site: 'site-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(html).toContain('1 page skipped (N/A)');
+    expect(html).not.toContain('1/1 pages have valid self-referential canonicals');
+  });
+
+  it('describes missing canonicals without calling them broken targets', async () => {
+    const { cachedAuditSite } = await import('@/lib/audit');
+    vi.mocked(cachedAuditSite).mockResolvedValueOnce({
+      ...makeAuditResult(),
+      metaTags: [{
+        page: '/',
+        canonicalValid: null,
+        canonicalStatus: null,
+        canonicalTarget: null,
+        title: makeCheckResult({ label: 'title' }),
+        description: makeCheckResult({ label: 'description' }),
+        ogTitle: makeCheckResult({ label: 'og:title' }),
+        ogImage: makeCheckResult({ label: 'og:image' }),
+        ogDescription: makeCheckResult({ label: 'og:description' }),
+        twitterCard: makeCheckResult({ label: 'twitter:card' }),
+        canonical: makeCheckResult({ status: 'fail', label: 'canonical', message: 'Not found' }),
+        jsonLd: makeCheckResult({ label: 'JSON-LD' }),
+      }],
+    });
+
+    const html = renderToStaticMarkup(await SiteDashboardPage({
+      params: Promise.resolve({ site: 'site-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(html).toContain('1 page missing canonical tags');
+    expect(html).not.toContain('failing canonical targets');
   });
 });

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,6 +1,7 @@
 import { getManagedSites, getSCUrl, type Site } from './sites';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { getAuth } from './google-auth';
+import { normalizeSkipChecks, type SkipCheckId } from './skip-checks';
 
 export type CheckStatus = 'pass' | 'warn' | 'fail' | 'error';
 
@@ -28,6 +29,9 @@ interface SitemapResult extends CheckResult {
 interface MetaTagResult {
   page: string;
   ogImageUrl?: string;
+  canonicalValid: boolean | null;
+  canonicalStatus: number | null;
+  canonicalTarget: string | null;
   title: CheckResult;
   description: CheckResult;
   ogTitle: CheckResult;
@@ -88,6 +92,15 @@ interface IndexingCoverageResult extends CheckResult {
   coveragePct?: number;
 }
 
+function applySkipToCheck<T extends CheckResult>(check: T, skip: Set<SkipCheckId>, checkId: SkipCheckId): T {
+  if (!skip.has(checkId)) return check;
+  return {
+    ...check,
+    status: 'pass',
+    message: `N/A — ${check.message}`,
+  };
+}
+
 export interface SiteAuditResult {
   siteId: string;
   domain: string;
@@ -124,7 +137,10 @@ export interface FetchResult {
 const MAX_RETRIES = 3;
 const BASE_DELAY = 1_000;
 
-async function safeFetch(url: string, opts?: { ua?: string }): Promise<FetchResult> {
+async function safeFetch(
+  url: string,
+  opts?: { ua?: string; method?: string; redirect?: RequestRedirect; timeoutMs?: number },
+): Promise<FetchResult> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     if (attempt > 0) {
       const delay = BASE_DELAY * Math.pow(2, attempt - 1);
@@ -133,9 +149,10 @@ async function safeFetch(url: string, opts?: { ua?: string }): Promise<FetchResu
     const start = Date.now();
     try {
       const res = await fetch(url, {
-        signal: AbortSignal.timeout(FETCH_TIMEOUT),
+        signal: AbortSignal.timeout(opts?.timeoutMs ?? FETCH_TIMEOUT),
         headers: opts?.ua ? { 'User-Agent': opts.ua } : undefined,
-        redirect: 'follow',
+        method: opts?.method,
+        redirect: opts?.redirect ?? 'follow',
       });
       const ttfbMs = Date.now() - start;
       if (res.status === 429 && attempt < MAX_RETRIES) continue;
@@ -248,6 +265,9 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
     const errResult: CheckResult = { status: 'error', label: '', message: res.error || `HTTP ${res.status}` };
     return {
       page,
+      canonicalValid: null,
+      canonicalStatus: null,
+      canonicalTarget: null,
       title: { ...errResult, label: 'title' }, description: { ...errResult, label: 'description' },
       ogTitle: { ...errResult, label: 'og:title' }, ogImage: { ...errResult, label: 'og:image' },
       ogDescription: { ...errResult, label: 'og:description' }, twitterCard: { ...errResult, label: 'twitter:card' },
@@ -287,6 +307,9 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   return {
     page,
     ogImageUrl: ogImage || undefined,
+    canonicalValid: null,
+    canonicalStatus: null,
+    canonicalTarget: canonical,
     title: titleCheck,
     description: makeCheck('description', desc, 10),
     ogTitle: makeCheck('og:title', ogTitle),
@@ -297,6 +320,110 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
     jsonLd: hasJsonLd
       ? { status: 'pass', label: 'JSON-LD', message: jsonLdType ? `Found (${jsonLdType})` : 'Found' }
       : { status: 'fail', label: 'JSON-LD', message: 'Not found' },
+  };
+}
+
+function normalizeComparableUrl(url: URL): string {
+  const pathname = url.pathname !== '/' && url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
+  return `${url.origin}${pathname}${url.search}`;
+}
+
+async function checkCanonicalUrl(
+  pageUrl: string,
+  canonicalHref: string | null,
+): Promise<{ check: CheckResult; canonicalValid: boolean | null; canonicalStatus: number | null; canonicalTarget: string | null }> {
+  if (!canonicalHref) {
+    return {
+      check: { status: 'fail', label: 'canonical', message: 'Not found' },
+      canonicalValid: null,
+      canonicalStatus: null,
+      canonicalTarget: null,
+    };
+  }
+
+  let canonicalUrl: URL;
+  try {
+    canonicalUrl = new URL(canonicalHref, pageUrl);
+  } catch {
+    return {
+      check: { status: 'fail', label: 'canonical', message: 'Invalid canonical URL' },
+      canonicalValid: false,
+      canonicalStatus: null,
+      canonicalTarget: canonicalHref,
+    };
+  }
+
+  const target = canonicalUrl.toString();
+  const page = new URL(pageUrl);
+  const selfReferential = normalizeComparableUrl(page) === normalizeComparableUrl(canonicalUrl);
+  let res = await safeFetch(target, {
+    ua: GOOGLEBOT_UA,
+    method: 'HEAD',
+    redirect: 'manual',
+    timeoutMs: 5_000,
+  });
+  if (res.status === 405 || res.status === 501) {
+    res = await safeFetch(target, {
+      ua: GOOGLEBOT_UA,
+      method: 'GET',
+      redirect: 'manual',
+      timeoutMs: 5_000,
+    });
+  }
+
+  if (res.status >= 300 && res.status < 400) {
+    const location = res.headers.get('location');
+    return {
+      check: {
+        status: 'warn',
+        label: 'canonical',
+        message: `Canonical redirects (${res.status})`,
+        details: location ? `${target} -> ${location}` : target,
+      },
+      canonicalValid: false,
+      canonicalStatus: res.status,
+      canonicalTarget: target,
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      check: {
+        status: 'fail',
+        label: 'canonical',
+        message: res.error ? `Canonical check failed: ${res.error}` : `Canonical returns HTTP ${res.status}`,
+        details: target,
+      },
+      canonicalValid: false,
+      canonicalStatus: res.status || null,
+      canonicalTarget: target,
+    };
+  }
+
+  if (!selfReferential) {
+    return {
+      check: {
+        status: 'warn',
+        label: 'canonical',
+        message: 'Canonical points to a different URL',
+        details: target,
+      },
+      canonicalValid: false,
+      canonicalStatus: res.status,
+      canonicalTarget: target,
+    };
+  }
+
+  return {
+    check: {
+      status: 'pass',
+      label: 'canonical',
+      message: 'Self-referential canonical resolves',
+      details: target,
+    },
+    canonicalValid: true,
+    canonicalStatus: res.status,
+    canonicalTarget: target,
   };
 }
 
@@ -599,8 +726,16 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   const pageResults: { meta: MetaTagResult; images: ImageSeoResult; links: InternalLinkResult }[] = [];
   for (const page of site.testPages) {
     const res = await safeFetch(`https://${site.domain}${page}`, { ua: GOOGLEBOT_UA });
+    const meta = parseMetaTags(res, page);
+    if (res.ok) {
+      const canonicalCheck = await checkCanonicalUrl(`https://${site.domain}${page}`, meta.canonicalTarget);
+      meta.canonical = canonicalCheck.check;
+      meta.canonicalValid = canonicalCheck.canonicalValid;
+      meta.canonicalStatus = canonicalCheck.canonicalStatus;
+      meta.canonicalTarget = canonicalCheck.canonicalTarget;
+    }
     pageResults.push({
-      meta: parseMetaTags(res, page),
+      meta,
       images: res.ok ? checkImageSeo(res.text, page) : { page, totalImages: 0, withAlt: 0, withoutAlt: 0, withLazyLoading: 0, status: 'error' as CheckStatus, label: 'Images', message: res.error || `HTTP ${res.status}`, images: [] },
       links: res.ok ? checkInternalLinks(res.text, site.domain, page) : { page, internalLinks: 0, externalLinks: 0, status: 'error' as CheckStatus, label: 'Internal Links', message: res.error || `HTTP ${res.status}` },
     });
@@ -614,18 +749,45 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   const ogImage = await checkOgImage(ogImageUrl);
 
   // Apply skipChecks: replace skipped checks with a neutral pass so they don't affect the score
-  const skip = new Set((site.skipChecks || []).map(s => s.toLowerCase()));
-  const maybeSkip = (c: CheckResult): CheckResult =>
-    skip.has(c.label.toLowerCase())
-      ? { ...c, status: 'pass', message: `N/A — ${c.message}` }
-      : c;
+  const skip = new Set(normalizeSkipChecks(site.skipChecks));
+  const skippedRobotsTxt = applySkipToCheck(robotsTxt, skip, 'robotsTxt');
+  const skippedSitemap = applySkipToCheck(sitemap, skip, 'sitemap');
+  const skippedScSitemapFreshness = applySkipToCheck(scSitemapFreshness, skip, 'scSitemap');
+  const skippedIndexingCoverage = applySkipToCheck(indexingCoverage, skip, 'indexing');
+  const skippedOgImage = applySkipToCheck(ogImage, skip, 'ogImage');
+  const skippedTtfb = applySkipToCheck(ttfb, skip, 'ttfb');
+  const skippedSecurity = {
+    https: applySkipToCheck(security.https, skip, 'https'),
+    hsts: applySkipToCheck(security.hsts, skip, 'hsts'),
+    favicon: applySkipToCheck(security.favicon, skip, 'favicon'),
+  };
+  const skippedMetaTags = metaTags.map(meta => ({
+    ...meta,
+    title: applySkipToCheck(meta.title, skip, 'title'),
+    description: applySkipToCheck(meta.description, skip, 'description'),
+    ogTitle: applySkipToCheck(meta.ogTitle, skip, 'ogTitle'),
+    ogImage: applySkipToCheck(meta.ogImage, skip, 'ogImageMeta'),
+    ogDescription: applySkipToCheck(meta.ogDescription, skip, 'ogDescription'),
+    twitterCard: applySkipToCheck(meta.twitterCard, skip, 'twitterCard'),
+    canonical: applySkipToCheck(meta.canonical, skip, 'canonical'),
+    jsonLd: applySkipToCheck(meta.jsonLd, skip, 'jsonLd'),
+  }));
+  const skippedImageSeo = imageSeo.map(image => applySkipToCheck(image, skip, 'images'));
+  const skippedInternalLinks = internalLinks.map(link => applySkipToCheck(link, skip, 'internalLinks'));
 
   const allChecks: CheckResult[] = [
-    robotsTxt, sitemap, scSitemapFreshness, indexingCoverage, ogImage, ttfb,
-    maybeSkip(security.https), maybeSkip(security.hsts), maybeSkip(security.favicon),
-    ...metaTags.flatMap(m => [m.title, m.description, m.ogTitle, m.ogImage, m.ogDescription, m.twitterCard, m.canonical, m.jsonLd].map(maybeSkip)),
-    ...imageSeo.map(i => maybeSkip({ status: i.status, label: i.label, message: i.message })),
-    ...internalLinks.map(l => maybeSkip({ status: l.status, label: l.label, message: l.message })),
+    skippedRobotsTxt,
+    skippedSitemap,
+    skippedScSitemapFreshness,
+    skippedIndexingCoverage,
+    skippedOgImage,
+    skippedTtfb,
+    skippedSecurity.https,
+    skippedSecurity.hsts,
+    skippedSecurity.favicon,
+    ...skippedMetaTags.flatMap(m => [m.title, m.description, m.ogTitle, m.ogImage, m.ogDescription, m.twitterCard, m.canonical, m.jsonLd]),
+    ...skippedImageSeo,
+    ...skippedInternalLinks,
   ];
 
   const score = allChecks.reduce(
@@ -633,13 +795,22 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     { pass: 0, warn: 0, fail: 0, error: 0, total: 0 }
   );
 
-  const skippedSecurity = {
-    https: maybeSkip(security.https),
-    hsts: maybeSkip(security.hsts),
-    favicon: maybeSkip(security.favicon),
+  return {
+    siteId: site.id,
+    domain: site.domain,
+    timestamp: Date.now(),
+    robotsTxt: skippedRobotsTxt,
+    sitemap: skippedSitemap,
+    scSitemapFreshness: skippedScSitemapFreshness,
+    indexingCoverage: skippedIndexingCoverage,
+    metaTags: skippedMetaTags,
+    ogImage: skippedOgImage,
+    ttfb: skippedTtfb,
+    imageSeo: skippedImageSeo,
+    internalLinks: skippedInternalLinks,
+    security: skippedSecurity,
+    score,
   };
-
-  return { siteId: site.id, domain: site.domain, timestamp: Date.now(), robotsTxt, sitemap, scSitemapFreshness, indexingCoverage, metaTags, ogImage, ttfb, imageSeo, internalLinks, security: skippedSecurity, score };
 }
 
 async function auditAllSites(): Promise<SiteAuditResult[]> {

--- a/src/lib/canonical.ts
+++ b/src/lib/canonical.ts
@@ -1,0 +1,136 @@
+import type { CheckResult, CheckStatus, SiteAuditResult } from './audit';
+
+type CanonicalMetaTag = SiteAuditResult['metaTags'][number];
+
+interface CanonicalPageStats {
+  total: number;
+  skipped: number;
+  passes: number;
+  warns: number;
+  missing: number;
+  broken: number;
+}
+
+export interface CanonicalSummary {
+  status: CheckStatus;
+  label: string;
+  message: string;
+  compactLabel: string;
+}
+
+const SKIP_PREFIX = 'N/A';
+
+function isSkippedCheck(check: CheckResult): boolean {
+  return check.message.startsWith(SKIP_PREFIX);
+}
+
+function getCanonicalPageStats(metaTags: CanonicalMetaTag[]): CanonicalPageStats {
+  return metaTags.reduce<CanonicalPageStats>((acc, meta) => {
+    acc.total++;
+
+    if (isSkippedCheck(meta.canonical)) {
+      acc.skipped++;
+      return acc;
+    }
+
+    if (meta.canonical.status === 'warn') {
+      acc.warns++;
+      return acc;
+    }
+
+    if (meta.canonical.status === 'fail' || meta.canonical.status === 'error') {
+      if (meta.canonicalTarget === null) {
+        acc.missing++;
+      } else {
+        acc.broken++;
+      }
+      return acc;
+    }
+
+    acc.passes++;
+    return acc;
+  }, { total: 0, skipped: 0, passes: 0, warns: 0, missing: 0, broken: 0 });
+}
+
+export function summarizeCanonicalChecks(metaTags: CanonicalMetaTag[]): CanonicalSummary {
+  const stats = getCanonicalPageStats(metaTags);
+
+  if (stats.total === 0) {
+    return {
+      status: 'pass',
+      label: 'Canonical URL',
+      message: 'No pages checked for canonical URLs',
+      compactLabel: 'No pages',
+    };
+  }
+
+  if (stats.missing > 0 && stats.broken > 0) {
+    const issues = stats.missing + stats.broken;
+    return {
+      status: 'fail',
+      label: 'Canonical URL',
+      message: `${issues} page${issues === 1 ? '' : 's'} have canonical issues (${stats.missing} missing, ${stats.broken} broken targets)`,
+      compactLabel: `${issues} issue${issues === 1 ? '' : 's'}`,
+    };
+  }
+
+  if (stats.missing > 0) {
+    return {
+      status: 'fail',
+      label: 'Canonical URL',
+      message: `${stats.missing} page${stats.missing === 1 ? '' : 's'} missing canonical tags`,
+      compactLabel: `${stats.missing} issue${stats.missing === 1 ? '' : 's'}`,
+    };
+  }
+
+  if (stats.broken > 0) {
+    return {
+      status: 'fail',
+      label: 'Canonical URL',
+      message: `${stats.broken} page${stats.broken === 1 ? '' : 's'} have failing canonical targets`,
+      compactLabel: `${stats.broken} issue${stats.broken === 1 ? '' : 's'}`,
+    };
+  }
+
+  if (stats.warns > 0) {
+    return {
+      status: 'warn',
+      label: 'Canonical URL',
+      message: `${stats.warns} page${stats.warns === 1 ? '' : 's'} have canonical warnings`,
+      compactLabel: `${stats.warns} warning${stats.warns === 1 ? '' : 's'}`,
+    };
+  }
+
+  if (stats.skipped === stats.total) {
+    return {
+      status: 'pass',
+      label: 'Canonical URL',
+      message: `${stats.skipped} page${stats.skipped === 1 ? '' : 's'} skipped (N/A)`,
+      compactLabel: `${stats.skipped} skipped`,
+    };
+  }
+
+  if (stats.skipped > 0) {
+    return {
+      status: 'pass',
+      label: 'Canonical URL',
+      message: `${stats.passes}/${stats.total} pages have valid self-referential canonicals, ${stats.skipped} skipped`,
+      compactLabel: `${stats.passes}/${stats.total} pass, ${stats.skipped} skipped`,
+    };
+  }
+
+  return {
+    status: 'pass',
+    label: 'Canonical URL',
+    message: `${stats.total}/${stats.total} pages have valid self-referential canonicals`,
+    compactLabel: `${stats.total}/${stats.total} pass`,
+  };
+}
+
+export function getMissingCanonicalPages(metaTags: CanonicalMetaTag[]): CanonicalMetaTag[] {
+  return metaTags.filter((meta) => meta.canonical.status === 'fail' && meta.canonicalTarget === null);
+}
+
+export function getBrokenCanonicalPages(metaTags: CanonicalMetaTag[]): CanonicalMetaTag[] {
+  return metaTags.filter((meta) => meta.canonical.status === 'fail' && meta.canonicalTarget !== null);
+}

--- a/src/lib/gaps.ts
+++ b/src/lib/gaps.ts
@@ -1,4 +1,5 @@
 import type { SiteAuditResult } from './audit';
+import { getBrokenCanonicalPages, getMissingCanonicalPages } from './canonical';
 import type { Site } from './sites';
 
 export type GapSeverity = 'high' | 'medium' | 'low';
@@ -170,7 +171,7 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site): SiteGapAnal
   }
 
   // HIGH: missing canonical tags
-  const pagesWithoutCanonical = audit.metaTags.filter(m => m.canonical.status === 'fail');
+  const pagesWithoutCanonical = getMissingCanonicalPages(audit.metaTags);
   if (pagesWithoutCanonical.length > 0) {
     gaps.push({
       id: 'missing-canonical',
@@ -180,6 +181,19 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site): SiteGapAnal
       category: 'indexing',
       hint: 'Add <link rel="canonical" href="https://' + site.domain + '/page-path"> to every page. Use absolute URLs including protocol. Self-referencing canonicals are fine.',
       affectedPages: pagesWithoutCanonical.map(m => m.page),
+    });
+  }
+
+  const pagesWithBrokenCanonical = getBrokenCanonicalPages(audit.metaTags);
+  if (pagesWithBrokenCanonical.length > 0) {
+    gaps.push({
+      id: 'broken-canonical-targets',
+      title: 'Fix broken canonical targets',
+      description: 'Some pages already declare canonical URLs, but those targets are invalid or unavailable. Broken canonicals send conflicting indexing signals and can prevent search engines from trusting the preferred URL.',
+      severity: 'high',
+      category: 'indexing',
+      hint: 'Update each canonical to a live absolute URL that resolves without errors. Prefer self-referential canonicals for indexable pages and verify the final target returns HTTP 200.',
+      affectedPages: pagesWithBrokenCanonical.map((meta) => meta.page),
     });
   }
 
@@ -279,6 +293,7 @@ const GAP_SECTION_MAP: Record<string, string> = {
   'stale-sitemap': 'sitemap',
   'weak-meta-tags': 'metaTags',
   'missing-canonical': 'metaTags',
+  'broken-canonical-targets': 'metaTags',
   'missing-twitter-card': 'metaTags',
   'missing-og-image': 'ogImage',
   'missing-json-ld': 'metaTags',

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -8,7 +8,7 @@ export interface Site {
   searchConsole?: boolean;
   color?: string;
   testPages: string[];
-  /** Audit check labels to skip (mark as N/A) — for checks that can't be fixed by the site owner. */
+  /** Audit check ids to skip (mark as N/A) — for checks that can't be fixed by the site owner. */
   skipChecks?: string[];
 }
 
@@ -34,6 +34,7 @@ export function getSCUrl(site: Site): string {
 
 import { dbGetSites } from './db';
 import { normalizeSiteDomain, isValidSiteId, getSiteScUrlOverride } from './site-domain';
+import { normalizeSkipChecks } from './skip-checks';
 
 const GA4_PROPERTY_RE = /^properties\/\d+$/;
 
@@ -93,7 +94,11 @@ export function validateAndNormalizeSiteInput(
   };
   if (scUrl) site.scUrl = scUrl; else delete site.scUrl;
   if (rawGa4) site.ga4PropertyId = rawGa4; else delete site.ga4PropertyId;
-  if (!Array.isArray(body.skipChecks)) delete site.skipChecks;
+  if (Array.isArray(body.skipChecks)) {
+    site.skipChecks = normalizeSkipChecks(body.skipChecks.filter((value): value is string => typeof value === 'string'));
+  } else {
+    delete site.skipChecks;
+  }
 
   delete (site as unknown as Record<string, unknown>).sortOrder;
 

--- a/src/lib/skip-checks.ts
+++ b/src/lib/skip-checks.ts
@@ -1,0 +1,107 @@
+export type SkipCheckId =
+  | 'robotsTxt'
+  | 'sitemap'
+  | 'scSitemap'
+  | 'indexing'
+  | 'title'
+  | 'description'
+  | 'ogTitle'
+  | 'ogDescription'
+  | 'ogImageMeta'
+  | 'ogImage'
+  | 'twitterCard'
+  | 'canonical'
+  | 'jsonLd'
+  | 'https'
+  | 'hsts'
+  | 'favicon'
+  | 'ttfb'
+  | 'images'
+  | 'internalLinks';
+
+export interface SkipCheckOption {
+  id: SkipCheckId;
+  label: string;
+  aliases?: string[];
+}
+
+export const SKIP_CHECK_OPTIONS: SkipCheckOption[] = [
+  { id: 'robotsTxt', label: 'robots.txt' },
+  { id: 'sitemap', label: 'Sitemap' },
+  { id: 'scSitemap', label: 'SC Sitemap' },
+  { id: 'indexing', label: 'Indexing' },
+  { id: 'title', label: 'title' },
+  { id: 'description', label: 'description' },
+  { id: 'ogTitle', label: 'og:title' },
+  { id: 'ogDescription', label: 'og:description' },
+  { id: 'ogImageMeta', label: 'og:image', aliases: ['meta-og-image'] },
+  { id: 'ogImage', label: 'OG Image' },
+  { id: 'twitterCard', label: 'twitter:card' },
+  { id: 'canonical', label: 'canonical' },
+  { id: 'jsonLd', label: 'JSON-LD' },
+  { id: 'https', label: 'HTTPS' },
+  { id: 'hsts', label: 'HSTS' },
+  { id: 'favicon', label: 'Favicon' },
+  { id: 'ttfb', label: 'TTFB' },
+  { id: 'images', label: 'Images' },
+  { id: 'internalLinks', label: 'Internal Links' },
+];
+
+function normalizeLooseKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+const EXACT_ID_LOOKUP = new Map<string, SkipCheckId>();
+const LOOSE_ID_LOOKUP = new Map<string, SkipCheckId>();
+
+for (const option of SKIP_CHECK_OPTIONS) {
+  const rawKeys = [option.id, option.label, ...(option.aliases ?? [])];
+  for (const rawKey of rawKeys) {
+    EXACT_ID_LOOKUP.set(rawKey.toLowerCase(), option.id);
+  }
+
+  const looseKeys =
+    option.id === 'ogImageMeta'
+      ? ['metaogimage', 'metaog']
+      : rawKeys.map(normalizeLooseKey);
+
+  for (const looseKey of looseKeys) {
+    if (looseKey) {
+      LOOSE_ID_LOOKUP.set(looseKey, option.id);
+    }
+  }
+}
+
+export function getSkipCheckId(value: string): SkipCheckId | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return EXACT_ID_LOOKUP.get(trimmed.toLowerCase()) ?? LOOSE_ID_LOOKUP.get(normalizeLooseKey(trimmed)) ?? null;
+}
+
+export function normalizeSkipChecks(values: string[] | undefined): SkipCheckId[] {
+  if (!values?.length) return [];
+
+  const normalized: SkipCheckId[] = [];
+  const seen = new Set<SkipCheckId>();
+
+  for (const value of values) {
+    const id = getSkipCheckId(value);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id);
+  }
+
+  return normalized;
+}
+
+export function hasSkipCheck(values: string[] | undefined, id: SkipCheckId): boolean {
+  return normalizeSkipChecks(values).includes(id);
+}
+
+export function toggleSkipCheck(values: string[] | undefined, id: SkipCheckId, checked: boolean): SkipCheckId[] {
+  const normalized = normalizeSkipChecks(values);
+  if (checked) {
+    return normalized.includes(id) ? normalized : [...normalized, id];
+  }
+  return normalized.filter((value) => value !== id);
+}


### PR DESCRIPTION
Closes #34

Picked ready issue `#34`, validated the referenced code existed, created the TamTam issue branch, implemented canonical validation plus UI surfacing, and stopped before test/review/commit steps.

---
Implemented via TamTam from issue [#34](https://github.com/3h4x/seo-tools/issues/34).