### PR TITLE
fix: Surface collector and sitemap sync freshness so background job failures stop being silent

### DIFF
--- a/app/api/config/operations/route.ts
+++ b/app/api/config/operations/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getOperationalStatuses } from '@/lib/db';
+
+export async function GET() {
+  try {
+    return NextResponse.json({ statuses: await getOperationalStatuses() });
+  } catch (error) {
+    console.error('[GET /api/config/operations]', error);
+    return NextResponse.json({ error: 'failed_to_load_operational_status' }, { status: 500 });
+  }
+}

--- a/app/components/operational-status-panel.tsx
+++ b/app/components/operational-status-panel.tsx
@@ -1,0 +1,61 @@
+import { formatRelativeTime } from '@/lib/format';
+import type { OperationalStatus } from '@/lib/db';
+
+const STATE_STYLES: Record<OperationalStatus['state'], string> = {
+  fresh: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
+  stale: 'bg-amber-500/15 text-amber-300 border border-amber-500/30',
+  never: 'bg-neutral-800 text-neutral-400 border border-neutral-700',
+};
+
+const STATE_LABELS: Record<OperationalStatus['state'], string> = {
+  fresh: 'Fresh',
+  stale: 'Stale',
+  never: 'Never',
+};
+
+function renderTimestamp(timestamp: number | null): string {
+  if (timestamp === null) return 'No timestamp yet';
+  return `Updated ${formatRelativeTime(timestamp)}`;
+}
+
+export default function OperationalStatusPanel({
+  statuses,
+  error = false,
+}: {
+  statuses: OperationalStatus[];
+  error?: boolean;
+}) {
+  return (
+    <section className="space-y-3 max-w-5xl">
+      <div className="flex items-center gap-3">
+        <h2 className="text-base font-semibold text-white">Operational Status</h2>
+        <span className="text-xs px-2 py-0.5 rounded bg-neutral-800 text-neutral-400">Cached status</span>
+      </div>
+      <p className="text-xs text-neutral-500">
+        Freshness is derived from collector, sitemap sync, and snapshot records. GA4 coverage may fall back to saved property IDs when discovery data is unavailable.
+      </p>
+      {error && (
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
+          Operational status could not be loaded. Config and site management are still available.
+        </div>
+      )}
+      <div className="grid gap-3 md:grid-cols-2">
+        {statuses.map((status) => (
+          <div key={status.key} className="rounded-lg border border-neutral-800 bg-neutral-900 p-4 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-medium text-white">{status.label}</h3>
+              <span className={`rounded-full px-2 py-0.5 text-xs ${STATE_STYLES[status.state]}`}>
+                {STATE_LABELS[status.state]}
+              </span>
+            </div>
+            <p className="text-sm text-neutral-200">{status.reason}</p>
+            <div className="space-y-1 text-xs text-neutral-500">
+              <p>{renderTimestamp(status.timestamp)}</p>
+              {status.details && <p>{status.details}</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -2,28 +2,65 @@
 
 import { useEffect, useState } from 'react';
 import ConfigForm from '../components/config-form';
+import OperationalStatusPanel from '../components/operational-status-panel';
 import PagespeedKeyForm from '../components/pagespeed-key-form';
 import SitesManager from '../components/sites-manager';
+import type { OperationalStatus } from '@/lib/db';
 import type { Site } from '@/lib/sites';
 
 export default function ConfigPage() {
   const [source, setSource] = useState<'db' | 'env' | 'none'>('none');
   const [sites, setSites] = useState<Site[]>([]);
+  const [statuses, setStatuses] = useState<OperationalStatus[]>([]);
+  const [statusError, setStatusError] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch config from API to ensure fresh data
-    Promise.all([
-      fetch('/api/config').then(r => r.json()),
-      fetch('/api/sites').then(r => r.json()),
-    ]).then(([config, sitesData]) => {
-      setSource(config.source);
-      setSites(sitesData);
-      setLoading(false);
-    }).catch(err => {
-      console.error('Failed to load config:', err);
+    let active = true;
+
+    Promise.allSettled([
+      fetch('/api/config').then(async (r) => {
+        if (!r.ok) throw new Error('config');
+        return r.json() as Promise<{ source: 'db' | 'env' | 'none' }>;
+      }),
+      fetch('/api/sites').then(async (r) => {
+        if (!r.ok) throw new Error('sites');
+        return r.json() as Promise<Site[]>;
+      }),
+      fetch('/api/config/operations').then(async (r) => {
+        if (!r.ok) throw new Error('operations');
+        return r.json() as Promise<{ statuses: OperationalStatus[] }>;
+      }),
+    ]).then(([configResult, sitesResult, operationsResult]) => {
+      if (!active) return;
+
+      if (configResult.status === 'fulfilled') {
+        setSource(configResult.value.source);
+      } else {
+        console.error('Failed to load config source:', configResult.reason);
+      }
+
+      if (sitesResult.status === 'fulfilled') {
+        setSites(sitesResult.value);
+      } else {
+        console.error('Failed to load sites:', sitesResult.reason);
+      }
+
+      if (operationsResult.status === 'fulfilled') {
+        setStatuses(operationsResult.value.statuses);
+        setStatusError(false);
+      } else {
+        console.error('Failed to load operational status:', operationsResult.reason);
+        setStatuses([]);
+        setStatusError(true);
+      }
+
       setLoading(false);
     });
+
+    return () => {
+      active = false;
+    };
   }, []);
 
   if (loading) {
@@ -35,6 +72,8 @@ export default function ConfigPage() {
   return (
     <div className="p-6 space-y-10">
       <ConfigForm source={source} />
+      <hr className="border-neutral-800" />
+      <OperationalStatusPanel statuses={statuses} error={statusError} />
       <hr className="border-neutral-800" />
       <PagespeedKeyForm />
       <hr className="border-neutral-800" />

--- a/src/lib/__tests__/api-config-operations.test.ts
+++ b/src/lib/__tests__/api-config-operations.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetOperationalStatuses,
+} = vi.hoisted(() => ({
+  mockGetOperationalStatuses: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getOperationalStatuses: mockGetOperationalStatuses,
+}));
+
+import { GET } from '../../../app/api/config/operations/route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/config/operations', () => {
+  it('returns the operational statuses from the DB helper', async () => {
+    mockGetOperationalStatuses.mockResolvedValue([
+      {
+        key: 'sc-daily',
+        label: 'Daily Search Console',
+        state: 'fresh',
+        timestamp: 123,
+        reason: 'ok',
+        details: 'Collector writes are current',
+      },
+      {
+        key: 'ga4-daily',
+        label: 'Daily GA4',
+        state: 'fresh',
+        timestamp: 456,
+        reason: 'Collected 1 site through 2026-05-11',
+        details: 'GA4 discovery unavailable; excluding sites without saved GA4 property IDs: site-a',
+      },
+    ]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      statuses: [
+        {
+          key: 'sc-daily',
+          label: 'Daily Search Console',
+          state: 'fresh',
+          timestamp: 123,
+          reason: 'ok',
+          details: 'Collector writes are current',
+        },
+        {
+          key: 'ga4-daily',
+          label: 'Daily GA4',
+          state: 'fresh',
+          timestamp: 456,
+          reason: 'Collected 1 site through 2026-05-11',
+          details: 'GA4 discovery unavailable; excluding sites without saved GA4 property IDs: site-a',
+        },
+      ],
+    });
+  });
+
+  it('returns 500 when the helper throws', async () => {
+    mockGetOperationalStatuses.mockRejectedValue(new Error('boom'));
+
+    const res = await GET();
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'failed_to_load_operational_status' });
+  });
+});

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -1,9 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  mockListAccountSummaries,
+  mockGetAuth,
+} = vi.hoisted(() => ({
+  mockListAccountSummaries: vi.fn(),
+  mockGetAuth: vi.fn(),
+}));
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return { ...actual, existsSync: () => true, mkdirSync: () => undefined };
 });
+
+vi.mock('@google-analytics/admin', () => ({
+  AnalyticsAdminServiceClient: function AnalyticsAdminServiceClient() {
+    return {
+      listAccountSummaries: mockListAccountSummaries,
+    };
+  },
+}));
+
+vi.mock('../google-auth', () => ({
+  getAuth: mockGetAuth,
+}));
 
 vi.mock('../sqlite-driver.js', async () => {
   const actual = await vi.importActual<typeof import('../sqlite-driver.js')>('../sqlite-driver.js');
@@ -27,6 +47,11 @@ import {
   getConfig,
   setConfig,
   deleteConfig,
+  getOperationalStatuses,
+  getScDailyOperationalStatus,
+  getGa4DailyOperationalStatus,
+  getSitemapSyncOperationalStatus,
+  getSnapshotOperationalStatus,
 } from '../db';
 
 /** Wipe volatile tables between tests so state never leaks. */
@@ -48,6 +73,10 @@ function resetDb() {
 }
 
 beforeEach(resetDb);
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
 
 // ---------------------------------------------------------------------------
 // getCached / setCache
@@ -251,5 +280,179 @@ describe('config helpers', () => {
 
   it('delete is a no-op for missing key', () => {
     expect(() => deleteConfig('missing')).not.toThrow();
+  });
+});
+
+describe('operational status helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-12T12:00:00Z'));
+  });
+
+  function insertSite(overrides: Partial<Parameters<typeof dbUpsertSite>[0]> = {}) {
+    const site = {
+      id: overrides.id ?? 'site-a',
+      name: overrides.name ?? 'Site A',
+      domain: overrides.domain ?? 'a.example',
+      testPages: overrides.testPages ?? ['/'],
+      ...overrides,
+    };
+    dbUpsertSite(site);
+  }
+
+  it('returns never states when no operational rows exist yet', async () => {
+    mockListAccountSummaries.mockResolvedValue([[]]);
+
+    const statuses = await getOperationalStatuses();
+    expect(statuses.map((status) => status.state)).toEqual(['never', 'never', 'never', 'never']);
+  });
+
+  it('returns fresh states when all managed-site rows are current', async () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example', ga4PropertyId: 'properties/123' });
+    mockListAccountSummaries.mockResolvedValue([[]]);
+
+    db.prepare(
+      'INSERT INTO sc_daily (site_id, date, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-10', 10, 100, 0.1, 4.2, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO sitemap_state (site_id, sitemap_url, content_hash, url_count, latest_lastmod, last_submitted_at, last_checked_at, submit_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', 'https://example.com/sitemap.xml', 'hash', 10, '2026-05-11', Date.parse('2026-05-12T09:00:00Z'), Date.parse('2026-05-12T10:00:00Z'), 2);
+    db.prepare(
+      'INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 'https://example.com/', 10, 100, 0.1, 4.2, '2026-05-12 06:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
+
+    expect(getScDailyOperationalStatus().state).toBe('fresh');
+    expect((await getGa4DailyOperationalStatus()).state).toBe('fresh');
+    expect(getSitemapSyncOperationalStatus().state).toBe('fresh');
+    expect((await getSnapshotOperationalStatus()).state).toBe('fresh');
+    expect((await getSnapshotOperationalStatus()).details).toContain('SC and GA4');
+  });
+
+  it('returns stale states when configured sites are missing rows', async () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example', ga4PropertyId: 'properties/123' });
+    insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456' });
+    mockListAccountSummaries.mockResolvedValue([[]]);
+
+    db.prepare(
+      'INSERT INTO sc_daily (site_id, date, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-10', 10, 100, 0.1, 4.2, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO sitemap_state (site_id, sitemap_url, content_hash, url_count, latest_lastmod, last_submitted_at, last_checked_at, submit_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', 'https://a.example/sitemap.xml', 'hash', 10, '2026-05-11', Date.parse('2026-05-12T09:00:00Z'), Date.parse('2026-05-12T10:00:00Z'), 2);
+    db.prepare(
+      'INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 'https://a.example/', 10, 100, 0.1, 4.2, '2026-05-12 06:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
+
+    expect(getScDailyOperationalStatus().state).toBe('stale');
+    expect(getScDailyOperationalStatus().details).toContain('site-b');
+    expect((await getGa4DailyOperationalStatus()).state).toBe('stale');
+    expect((await getGa4DailyOperationalStatus()).details).toContain('site-b');
+    expect(getSitemapSyncOperationalStatus().state).toBe('stale');
+    expect(getSitemapSyncOperationalStatus().details).toContain('site-b');
+    expect((await getSnapshotOperationalStatus()).state).toBe('stale');
+    expect((await getSnapshotOperationalStatus()).details).toContain('SC');
+    expect((await getSnapshotOperationalStatus()).details).toContain('GA4');
+  });
+
+  it('returns stale states when freshness windows are missed for existing rows', async () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example', ga4PropertyId: 'properties/123' });
+    mockListAccountSummaries.mockResolvedValue([[]]);
+
+    db.prepare(
+      'INSERT INTO sc_daily (site_id, date, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-07', 10, 100, 0.1, 4.2, '2026-05-08 00:00:00');
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-09', 20, 30, 40, 0.4, 12, '2026-05-10 00:00:00');
+    db.prepare(
+      'INSERT INTO sitemap_state (site_id, sitemap_url, content_hash, url_count, latest_lastmod, last_submitted_at, last_checked_at, submit_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', 'https://a.example/sitemap.xml', 'hash', 10, '2026-05-11', Date.parse('2026-05-10T07:00:00Z'), Date.parse('2026-05-10T08:00:00Z'), 2);
+    db.prepare(
+      'INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-09', 'https://a.example/', 10, 100, 0.1, 4.2, '2026-05-09 06:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-a', '2026-05-09', 20, 30, 40, 0.4, 12, '2026-05-09 06:00:00');
+
+    expect(getScDailyOperationalStatus().state).toBe('stale');
+    expect((await getGa4DailyOperationalStatus()).state).toBe('stale');
+    expect(getSitemapSyncOperationalStatus().state).toBe('stale');
+    expect((await getSnapshotOperationalStatus()).state).toBe('stale');
+    expect((await getSnapshotOperationalStatus()).details).not.toContain('audit');
+  });
+
+  it('treats auto-discovered GA4 sites as in-scope for daily and snapshot status', async () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example' });
+    insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456' });
+    mockListAccountSummaries.mockResolvedValue([[
+      {
+        propertySummaries: [
+          { displayName: 'a.example', property: 'properties/123' },
+        ],
+      },
+    ]]);
+
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
+
+    const ga4DailyStatus = await getGa4DailyOperationalStatus();
+    const snapshotStatus = await getSnapshotOperationalStatus();
+
+    expect(ga4DailyStatus.state).toBe('stale');
+    expect(ga4DailyStatus.details).toContain('site-a');
+    expect(snapshotStatus.state).toBe('stale');
+    expect(snapshotStatus.details).toContain('GA4');
+  });
+
+  it('surfaces configured-only fallback details when GA4 discovery is unavailable', async () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example', searchConsole: false });
+    insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456', searchConsole: false });
+    mockListAccountSummaries.mockRejectedValue(new Error('admin unavailable'));
+
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
+
+    const statuses = await getOperationalStatuses();
+    const ga4DailyStatus = statuses.find((status) => status.key === 'ga4-daily');
+    const snapshotStatus = statuses.find((status) => status.key === 'snapshots');
+
+    expect(ga4DailyStatus).toMatchObject({
+      state: 'fresh',
+      reason: 'Collected 1 site through 2026-05-11',
+    });
+    expect(ga4DailyStatus?.details).toContain('GA4 discovery unavailable');
+    expect(ga4DailyStatus?.details).toContain('site-a');
+
+    expect(snapshotStatus).toMatchObject({
+      state: 'fresh',
+      reason: 'Latest snapshot date 2026-05-11',
+    });
+    expect(snapshotStatus?.details).toContain('GA4 discovery unavailable');
+    expect(snapshotStatus?.details).toContain('site-a');
   });
 });

--- a/src/lib/__tests__/operational-status-panel.test.tsx
+++ b/src/lib/__tests__/operational-status-panel.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import OperationalStatusPanel from '../../../app/components/operational-status-panel';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-12T12:00:00Z'));
+});
+
+describe('OperationalStatusPanel', () => {
+  it('renders fresh, stale, and never states with reason text', () => {
+    const html = renderToStaticMarkup(
+      <OperationalStatusPanel
+        statuses={[
+          { key: 'sc-daily', label: 'Daily Search Console', state: 'fresh', timestamp: Date.now() - 5 * 60_000, reason: 'Latest collected date 2026-05-10', details: 'Collector writes are current' },
+          { key: 'sitemap-sync', label: 'Sitemap Sync', state: 'stale', timestamp: Date.now() - 10 * 60 * 60_000, reason: '1/3 sites not checked within 8h', details: 'Last submit 12h ago' },
+          { key: 'snapshots', label: 'Snapshots', state: 'never', timestamp: null, reason: 'No snapshot history recorded yet' },
+        ]}
+      />
+    );
+
+    expect(html).toContain('Operational Status');
+    expect(html).toContain('Cached status');
+    expect(html).toContain('Fresh');
+    expect(html).toContain('Stale');
+    expect(html).toContain('Never');
+    expect(html).toContain('Latest collected date 2026-05-10');
+    expect(html).toContain('1/3 sites not checked within 8h');
+    expect(html).toContain('No snapshot history recorded yet');
+    expect(html).toContain('GA4 coverage may fall back to saved property IDs when discovery data is unavailable.');
+    expect(html).toContain('Updated 5m ago');
+    expect(html).toContain('No timestamp yet');
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,14 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { computeKeywordDeltas, type KeywordDelta } from './keyword-history';
+import {
+  GA4_DISCOVERY_CACHE_KEY,
+  GA4_DISCOVERY_CACHE_SITE_ID,
+  resolveSiteGa4PropertyId,
+  type DiscoveredGa4Property,
+} from './ga4-discovery';
+import { getAuth } from './google-auth';
 import { openDatabase } from './sqlite-driver.js';
 
 const DB_PATH = path.join(process.cwd(), 'data', 'seo-tools.db');
@@ -410,6 +418,525 @@ export function getSnapshotCount(): number {
   const db = getDb();
   const row = db.prepare('SELECT COUNT(DISTINCT date) as count FROM sc_snapshots').get() as { count: number };
   return row.count;
+}
+
+export type OperationalStatusState = 'fresh' | 'stale' | 'never';
+
+export interface OperationalStatus {
+  key: 'sc-daily' | 'ga4-daily' | 'sitemap-sync' | 'snapshots';
+  label: string;
+  state: OperationalStatusState;
+  timestamp: number | null;
+  reason: string;
+  details?: string;
+}
+
+interface SiteIdRow {
+  id: string;
+}
+
+interface PerSiteDateFreshnessRow {
+  site_id: string;
+  latest_date: string | null;
+  latest_created_at: string | null;
+}
+
+interface SitemapStateRow {
+  site_id: string;
+  last_checked_at: number;
+  last_submitted_at: number | null;
+}
+
+interface SourceOperationalSummary {
+  label: string;
+  missingSites: string[];
+  staleSites: string[];
+  latestDate: string | null;
+  latestTimestamp: number | null;
+  hasData: boolean;
+}
+
+interface ResolvedGa4SiteScope {
+  siteIds: string[];
+  discoveryState: 'resolved' | 'configured-only';
+  excludedSiteIds: string[];
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAILY_STATUS_MAX_AGE_MS = 26 * HOUR_MS;
+const SITEMAP_STATUS_MAX_AGE_MS = 8 * HOUR_MS;
+const SNAPSHOT_STATUS_MAX_AGE_MS = 36 * HOUR_MS;
+
+function localDateStr(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function localDaysBack(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return localDateStr(date);
+}
+
+function parseSqliteTimestamp(value: string | null): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value.replace(' ', 'T') + 'Z');
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function ageHours(timestamp: number | null): number | null {
+  if (timestamp === null) return null;
+  return Math.floor((Date.now() - timestamp) / HOUR_MS);
+}
+
+function buildNeverStatus(
+  key: OperationalStatus['key'],
+  label: string,
+  reason: string,
+): OperationalStatus {
+  return { key, label, state: 'never', timestamp: null, reason };
+}
+
+function pluralizeSites(count: number): string {
+  return `${count} site${count === 1 ? '' : 's'}`;
+}
+
+function summarizeSites(siteIds: string[]): string {
+  if (siteIds.length === 0) return '';
+  if (siteIds.length <= 3) return siteIds.join(', ');
+  return `${siteIds.slice(0, 3).join(', ')} +${siteIds.length - 3} more`;
+}
+
+function getManagedSiteIds(filter: 'all' | 'search-console' | 'ga4'): string[] {
+  const db = getDb();
+  let sql = 'SELECT id FROM sites';
+  if (filter === 'search-console') {
+    sql += ' WHERE search_console = 1';
+  } else if (filter === 'ga4') {
+    sql += " WHERE ga4_property_id IS NOT NULL AND ga4_property_id != ''";
+  }
+  sql += ' ORDER BY sort_order ASC, id ASC';
+  return (db.prepare(sql).all() as SiteIdRow[]).map((row) => row.id);
+}
+
+async function fetchDiscoveredGa4Properties(): Promise<DiscoveredGa4Property[] | null> {
+  try {
+    const client = new AnalyticsAdminServiceClient({ auth: getAuth() });
+    const [summaries] = await client.listAccountSummaries({});
+    return summaries.flatMap((account) => (
+      (account.propertySummaries ?? []).flatMap((property) => {
+        const displayName = property.displayName?.trim();
+        const propertyId = property.property?.split('/')[1]?.trim();
+        if (!displayName || !propertyId) return [];
+        return [{ displayName, propertyId }];
+      })
+    ));
+  } catch (error) {
+    console.error('[getOperationalStatuses] failed to discover GA4 properties:', error);
+    return null;
+  }
+}
+
+async function getResolvedGa4SiteScope(): Promise<ResolvedGa4SiteScope> {
+  const sites = dbGetSites();
+  const configuredSiteIds = sites
+    .filter((site) => typeof site.ga4PropertyId === 'string' && site.ga4PropertyId.trim() !== '')
+    .map((site) => site.id);
+  const properties = await withCache<DiscoveredGa4Property[]>(
+    GA4_DISCOVERY_CACHE_KEY,
+    GA4_DISCOVERY_CACHE_SITE_ID,
+    fetchDiscoveredGa4Properties,
+  );
+  if (!properties) {
+    return {
+      siteIds: configuredSiteIds,
+      discoveryState: 'configured-only',
+      excludedSiteIds: sites
+        .filter((site) => !(typeof site.ga4PropertyId === 'string' && site.ga4PropertyId.trim() !== ''))
+        .map((site) => site.id),
+    };
+  }
+
+  return {
+    siteIds: sites.flatMap((site) => (
+      resolveSiteGa4PropertyId(site, properties) ? [site.id] : []
+    )),
+    discoveryState: 'resolved',
+    excludedSiteIds: [],
+  };
+}
+
+function getPerSiteDateFreshness(
+  table: 'sc_daily' | 'ga4_daily' | 'sc_snapshots' | 'ga4_snapshots',
+): Map<string, PerSiteDateFreshnessRow> {
+  const db = getDb();
+  const rows = db.prepare(
+    `SELECT site_id, MAX(date) as latest_date, MAX(created_at) as latest_created_at
+     FROM ${table}
+     GROUP BY site_id`,
+  ).all() as PerSiteDateFreshnessRow[];
+  return new Map(rows.map((row) => [row.site_id, row]));
+}
+
+function getLatestTimestamp(timestamps: Array<number | null>): number | null {
+  return timestamps.reduce<number | null>((max, timestamp) => {
+    if (timestamp === null) return max;
+    if (max === null || timestamp > max) return timestamp;
+    return max;
+  }, null);
+}
+
+function getLatestDate(dates: Array<string | null>): string | null {
+  return dates.reduce<string | null>((max, date) => {
+    if (!date) return max;
+    if (max === null || date > max) return date;
+    return max;
+  }, null);
+}
+
+function collectCoverageDetails(missingSites: string[], staleSites: string[]): string[] {
+  const details: string[] = [];
+  if (missingSites.length > 0) {
+    details.push(`Missing: ${summarizeSites(missingSites)}`);
+  }
+  if (staleSites.length > 0) {
+    details.push(`Stale: ${summarizeSites(staleSites)}`);
+  }
+  return details;
+}
+
+function getGa4DiscoveryFallbackDetail(scope: ResolvedGa4SiteScope): string | null {
+  if (scope.discoveryState !== 'configured-only' || scope.excludedSiteIds.length === 0) {
+    return null;
+  }
+
+  return `GA4 discovery unavailable; excluding sites without saved GA4 property IDs: ${summarizeSites(scope.excludedSiteIds)}`;
+}
+
+function appendStatusDetail(details: string | undefined, extraDetail: string | null): string | undefined {
+  if (!extraDetail) return details;
+  if (!details) return extraDetail;
+  return `${details} · ${extraDetail}`;
+}
+
+function getDailyCollectorStatus(
+  table: 'sc_daily' | 'ga4_daily',
+  key: OperationalStatus['key'],
+  label: string,
+  expectedLagDays: number,
+  managedSiteFilter: 'search-console' | 'ga4',
+): OperationalStatus {
+  const expectedSiteIds = getManagedSiteIds(managedSiteFilter);
+  if (expectedSiteIds.length === 0) {
+    return buildNeverStatus(key, label, `No configured ${label.toLowerCase()} sites yet`);
+  }
+
+  const latestExpectedDate = localDaysBack(expectedLagDays);
+  const perSiteRows = getPerSiteDateFreshness(table);
+  const missingSites: string[] = [];
+  const staleSites: string[] = [];
+  const populatedRows: PerSiteDateFreshnessRow[] = [];
+
+  for (const siteId of expectedSiteIds) {
+    const row = perSiteRows.get(siteId);
+    if (!row || !row.latest_date) {
+      missingSites.push(siteId);
+      continue;
+    }
+
+    populatedRows.push(row);
+    const timestamp = parseSqliteTimestamp(row.latest_created_at);
+    const dateFresh = row.latest_date >= latestExpectedDate;
+    const writeFresh = timestamp !== null && Date.now() - timestamp <= DAILY_STATUS_MAX_AGE_MS;
+    if (!dateFresh || !writeFresh) {
+      staleSites.push(siteId);
+    }
+  }
+
+  if (populatedRows.length === 0) {
+    return buildNeverStatus(
+      key,
+      label,
+      `No daily rows collected yet for ${pluralizeSites(expectedSiteIds.length)}`,
+    );
+  }
+
+  const latestDate = getLatestDate(populatedRows.map((row) => row.latest_date));
+  const latestTimestamp = getLatestTimestamp(
+    populatedRows.map((row) => parseSqliteTimestamp(row.latest_created_at)),
+  );
+
+  if (missingSites.length === 0 && staleSites.length === 0) {
+    return {
+      key,
+      label,
+      state: 'fresh',
+      timestamp: latestTimestamp,
+      reason: `Collected ${pluralizeSites(expectedSiteIds.length)} through ${latestDate}`,
+      details: 'Collector writes are current',
+    };
+  }
+
+  const detailParts = collectCoverageDetails(missingSites, staleSites);
+  return {
+    key,
+    label,
+    state: 'stale',
+    timestamp: latestTimestamp,
+    reason: `Expected ${pluralizeSites(expectedSiteIds.length)} through at least ${latestExpectedDate}`,
+    details: detailParts.join(' · '),
+  };
+}
+
+export function getScDailyOperationalStatus(): OperationalStatus {
+  return getDailyCollectorStatus('sc_daily', 'sc-daily', 'Daily Search Console', 2, 'search-console');
+}
+
+export async function getGa4DailyOperationalStatus(): Promise<OperationalStatus> {
+  const scope = await getResolvedGa4SiteScope();
+  const expectedSiteIds = scope.siteIds;
+  const fallbackDetail = getGa4DiscoveryFallbackDetail(scope);
+  if (expectedSiteIds.length === 0) {
+    return {
+      ...buildNeverStatus('ga4-daily', 'Daily GA4', 'No GA4 sites could be resolved for status checks'),
+      details: fallbackDetail ?? undefined,
+    };
+  }
+
+  const latestExpectedDate = localDaysBack(1);
+  const perSiteRows = getPerSiteDateFreshness('ga4_daily');
+  const missingSites: string[] = [];
+  const staleSites: string[] = [];
+  const populatedRows: PerSiteDateFreshnessRow[] = [];
+
+  for (const siteId of expectedSiteIds) {
+    const row = perSiteRows.get(siteId);
+    if (!row || !row.latest_date) {
+      missingSites.push(siteId);
+      continue;
+    }
+
+    populatedRows.push(row);
+    const timestamp = parseSqliteTimestamp(row.latest_created_at);
+    const dateFresh = row.latest_date >= latestExpectedDate;
+    const writeFresh = timestamp !== null && Date.now() - timestamp <= DAILY_STATUS_MAX_AGE_MS;
+    if (!dateFresh || !writeFresh) {
+      staleSites.push(siteId);
+    }
+  }
+
+  if (populatedRows.length === 0) {
+    return {
+      ...buildNeverStatus(
+        'ga4-daily',
+        'Daily GA4',
+        `No daily rows collected yet for ${pluralizeSites(expectedSiteIds.length)}`,
+      ),
+      details: fallbackDetail ?? undefined,
+    };
+  }
+
+  const latestDate = getLatestDate(populatedRows.map((row) => row.latest_date));
+  const latestTimestamp = getLatestTimestamp(
+    populatedRows.map((row) => parseSqliteTimestamp(row.latest_created_at)),
+  );
+
+  if (missingSites.length === 0 && staleSites.length === 0) {
+    return {
+      key: 'ga4-daily',
+      label: 'Daily GA4',
+      state: 'fresh',
+      timestamp: latestTimestamp,
+      reason: `Collected ${pluralizeSites(expectedSiteIds.length)} through ${latestDate}`,
+      details: appendStatusDetail('Collector writes are current', fallbackDetail),
+    };
+  }
+
+  const detailParts = collectCoverageDetails(missingSites, staleSites);
+  return {
+    key: 'ga4-daily',
+    label: 'Daily GA4',
+    state: 'stale',
+    timestamp: latestTimestamp,
+    reason: `Expected ${pluralizeSites(expectedSiteIds.length)} through at least ${latestExpectedDate}`,
+    details: appendStatusDetail(detailParts.join(' · '), fallbackDetail),
+  };
+}
+
+export function getSitemapSyncOperationalStatus(): OperationalStatus {
+  const db = getDb();
+  const expectedSiteIds = getManagedSiteIds('all');
+  if (expectedSiteIds.length === 0) {
+    return buildNeverStatus('sitemap-sync', 'Sitemap Sync', 'No managed sites configured yet');
+  }
+
+  const staleCutoff = Date.now() - SITEMAP_STATUS_MAX_AGE_MS;
+  const rows = db.prepare(
+    'SELECT site_id, last_checked_at, last_submitted_at FROM sitemap_state',
+  ).all() as SitemapStateRow[];
+  const rowMap = new Map(rows.map((row) => [row.site_id, row]));
+  const missingSites: string[] = [];
+  const staleSites: string[] = [];
+  const presentRows: SitemapStateRow[] = [];
+
+  for (const siteId of expectedSiteIds) {
+    const row = rowMap.get(siteId);
+    if (!row || row.last_checked_at === 0) {
+      missingSites.push(siteId);
+      continue;
+    }
+
+    presentRows.push(row);
+    if (row.last_checked_at < staleCutoff) {
+      staleSites.push(siteId);
+    }
+  }
+
+  if (presentRows.length === 0) {
+    return buildNeverStatus(
+      'sitemap-sync',
+      'Sitemap Sync',
+      `No sitemap sync state recorded yet for ${pluralizeSites(expectedSiteIds.length)}`,
+    );
+  }
+
+  const latestCheckedAt = getLatestTimestamp(presentRows.map((row) => row.last_checked_at));
+  const latestSubmittedAt = getLatestTimestamp(presentRows.map((row) => row.last_submitted_at));
+  const detailParts = collectCoverageDetails(missingSites, staleSites);
+  detailParts.unshift(
+    latestSubmittedAt === null
+      ? 'No sitemap submissions recorded yet'
+      : `Last submit ${ageHours(latestSubmittedAt)}h ago`,
+  );
+
+  if (missingSites.length === 0 && staleSites.length === 0) {
+    return {
+      key: 'sitemap-sync',
+      label: 'Sitemap Sync',
+      state: 'fresh',
+      timestamp: latestCheckedAt,
+      reason: `Checked all ${pluralizeSites(expectedSiteIds.length)} within 8h`,
+      details: detailParts[0],
+    };
+  }
+
+  return {
+    key: 'sitemap-sync',
+    label: 'Sitemap Sync',
+    state: 'stale',
+    timestamp: latestCheckedAt,
+    reason: `${missingSites.length + staleSites.length}/${expectedSiteIds.length} sites missing or overdue`,
+    details: detailParts.join(' · '),
+  };
+}
+
+export async function getSnapshotOperationalStatus(): Promise<OperationalStatus> {
+  const expectedDate = localDaysBack(1);
+  const ga4Scope = await getResolvedGa4SiteScope();
+  const fallbackDetail = getGa4DiscoveryFallbackDetail(ga4Scope);
+  const sources: Array<{
+    label: string;
+    expectedSiteIds: string[];
+    rows: Map<string, PerSiteDateFreshnessRow>;
+  }> = [
+    {
+      label: 'SC',
+      expectedSiteIds: getManagedSiteIds('search-console'),
+      rows: getPerSiteDateFreshness('sc_snapshots'),
+    },
+    {
+      label: 'GA4',
+      expectedSiteIds: ga4Scope.siteIds,
+      rows: getPerSiteDateFreshness('ga4_snapshots'),
+    },
+  ].filter((source) => source.expectedSiteIds.length > 0);
+
+  if (sources.length === 0) {
+    return {
+      ...buildNeverStatus('snapshots', 'Snapshots', 'No managed snapshot sources configured yet'),
+      details: fallbackDetail ?? undefined,
+    };
+  }
+
+  const summaries: SourceOperationalSummary[] = sources.map((source) => {
+    const missingSites: string[] = [];
+    const staleSites: string[] = [];
+    const presentRows: PerSiteDateFreshnessRow[] = [];
+
+    for (const siteId of source.expectedSiteIds) {
+      const row = source.rows.get(siteId);
+      if (!row || !row.latest_date) {
+        missingSites.push(siteId);
+        continue;
+      }
+
+      presentRows.push(row);
+      const timestamp = parseSqliteTimestamp(row.latest_created_at);
+      if (
+        row.latest_date < expectedDate
+        || timestamp === null
+        || Date.now() - timestamp > SNAPSHOT_STATUS_MAX_AGE_MS
+      ) {
+        staleSites.push(siteId);
+      }
+    }
+
+    return {
+      label: source.label,
+      missingSites,
+      staleSites,
+      latestDate: getLatestDate(presentRows.map((row) => row.latest_date)),
+      latestTimestamp: getLatestTimestamp(
+        presentRows.map((row) => parseSqliteTimestamp(row.latest_created_at)),
+      ),
+      hasData: presentRows.length > 0,
+    };
+  });
+
+  const populated = summaries.filter((summary) => summary.hasData);
+  if (populated.length === 0) {
+    return {
+      ...buildNeverStatus('snapshots', 'Snapshots', 'No snapshot history recorded yet'),
+      details: fallbackDetail ?? undefined,
+    };
+  }
+
+  const latestTimestamp = getLatestTimestamp(populated.map((summary) => summary.latestTimestamp));
+  const latestDate = getLatestDate(populated.map((summary) => summary.latestDate));
+  const staleSources = summaries.filter(
+    (summary) => summary.missingSites.length > 0 || summary.staleSites.length > 0,
+  );
+
+  if (staleSources.length === 0) {
+    return {
+      key: 'snapshots',
+      label: 'Snapshots',
+      state: 'fresh',
+      timestamp: latestTimestamp,
+      reason: `Latest snapshot date ${latestDate}`,
+      details: appendStatusDetail('SC and GA4 snapshots are current', fallbackDetail),
+    };
+  }
+
+  return {
+    key: 'snapshots',
+    label: 'Snapshots',
+    state: 'stale',
+    timestamp: latestTimestamp,
+    reason: `Latest snapshot date ${latestDate}`,
+    details: appendStatusDetail(
+      `Stale or missing sources: ${staleSources.map((summary) => summary.label).join(', ')}`,
+      fallbackDetail,
+    ),
+  };
+}
+
+export async function getOperationalStatuses(): Promise<OperationalStatus[]> {
+  return [
+    getScDailyOperationalStatus(),
+    await getGa4DailyOperationalStatus(),
+    getSitemapSyncOperationalStatus(),
+    await getSnapshotOperationalStatus(),
+  ];
 }
 
 // --- Config helpers ---

--- a/src/lib/ga4-discovery.ts
+++ b/src/lib/ga4-discovery.ts
@@ -1,0 +1,27 @@
+export const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
+export const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
+
+export interface DiscoveredGa4Property {
+  displayName: string;
+  propertyId: string;
+}
+
+interface SiteLike {
+  domain: string;
+  ga4PropertyId?: string;
+}
+
+export function resolveSiteGa4PropertyId(
+  site: SiteLike,
+  properties: DiscoveredGa4Property[],
+): string | undefined {
+  if (site.ga4PropertyId) return site.ga4PropertyId;
+
+  const domain = site.domain.toLowerCase();
+  const property = properties.find((candidate) => {
+    const displayName = candidate.displayName.toLowerCase();
+    return displayName.includes(domain) || domain.includes(displayName);
+  });
+
+  return property?.propertyId;
+}

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -3,14 +3,12 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getManagedSites } from './sites';
 import { clearCacheEntry, withCache, type ProviderResult } from './db';
-
-const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
-const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
-
-type DiscoveredGa4Property = {
-  displayName: string;
-  propertyId: string;
-};
+import {
+  GA4_DISCOVERY_CACHE_KEY,
+  GA4_DISCOVERY_CACHE_SITE_ID,
+  resolveSiteGa4PropertyId,
+  type DiscoveredGa4Property,
+} from './ga4-discovery';
 
 function getAdminClient() {
   return new AnalyticsAdminServiceClient({ auth: getAuth() });
@@ -57,17 +55,11 @@ export async function discoverPropertyIds() {
   if (!properties) return sites;
 
   return sites.map((site) => {
-      const domain = site.domain.toLowerCase();
-      const property = properties.find((p) => {
-        const displayName = p.displayName.toLowerCase();
-        return displayName.includes(domain) || domain.includes(displayName);
-      });
-
       return {
         ...site,
-        ga4PropertyId: site.ga4PropertyId || property?.propertyId,
+        ga4PropertyId: resolveSiteGa4PropertyId(site, properties),
       };
-    });
+  });
 }
 
 interface GA4Metrics {


### PR DESCRIPTION
Closes #43

Picked ready issue `#43`, created the TamTam issue branch, and implemented Config-side operational freshness visibility for collector, sitemap sync, and snapshot subsystems.

---
Implemented via TamTam from issue [#43](https://github.com/3h4x/seo-tools/issues/43).