### PR TITLE
chore(review): operational status contract still depends on live ga4 discovery

### DIFF
--- a/app/api/config/operations/route.ts
+++ b/app/api/config/operations/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getOperationalStatuses } from '@/lib/db';
 
-export async function GET() {
+export function GET() {
   try {
-    return NextResponse.json({ statuses: await getOperationalStatuses() });
+    return NextResponse.json({ statuses: getOperationalStatuses() });
   } catch (error) {
     console.error('[GET /api/config/operations]', error);
     return NextResponse.json({ error: 'failed_to_load_operational_status' }, { status: 500 });

--- a/src/lib/__tests__/api-config-operations.test.ts
+++ b/src/lib/__tests__/api-config-operations.test.ts
@@ -17,8 +17,8 @@ beforeEach(() => {
 });
 
 describe('GET /api/config/operations', () => {
-  it('returns the operational statuses from the DB helper', async () => {
-    mockGetOperationalStatuses.mockResolvedValue([
+  it('returns operational statuses from SQLite without calling live APIs', async () => {
+    mockGetOperationalStatuses.mockReturnValue([
       {
         key: 'sc-daily',
         label: 'Daily Search Console',
@@ -33,11 +33,11 @@ describe('GET /api/config/operations', () => {
         state: 'fresh',
         timestamp: 456,
         reason: 'Collected 1 site through 2026-05-11',
-        details: 'GA4 discovery unavailable; excluding sites without saved GA4 property IDs: site-a',
+        details: 'Collector writes are current',
       },
     ]);
 
-    const res = await GET();
+    const res = GET();
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -56,16 +56,43 @@ describe('GET /api/config/operations', () => {
           state: 'fresh',
           timestamp: 456,
           reason: 'Collected 1 site through 2026-05-11',
-          details: 'GA4 discovery unavailable; excluding sites without saved GA4 property IDs: site-a',
+          details: 'Collector writes are current',
+        },
+      ],
+    });
+  });
+
+  it('returns ga4-daily as never when no GA4 property IDs are configured', async () => {
+    mockGetOperationalStatuses.mockReturnValue([
+      {
+        key: 'ga4-daily',
+        label: 'Daily GA4',
+        state: 'never',
+        timestamp: null,
+        reason: 'No GA4 property IDs configured',
+      },
+    ]);
+
+    const res = GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      statuses: [
+        {
+          key: 'ga4-daily',
+          label: 'Daily GA4',
+          state: 'never',
+          timestamp: null,
+          reason: 'No GA4 property IDs configured',
         },
       ],
     });
   });
 
   it('returns 500 when the helper throws', async () => {
-    mockGetOperationalStatuses.mockRejectedValue(new Error('boom'));
+    mockGetOperationalStatuses.mockImplementation(() => { throw new Error('boom'); });
 
-    const res = await GET();
+    const res = GET();
 
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'failed_to_load_operational_status' });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -396,39 +396,10 @@ describe('operational status helpers', () => {
     expect((await getSnapshotOperationalStatus()).details).not.toContain('audit');
   });
 
-  it('treats auto-discovered GA4 sites as in-scope for daily and snapshot status', async () => {
-    const db = getDb();
-    insertSite({ id: 'site-a', domain: 'a.example' });
-    insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456' });
-    mockListAccountSummaries.mockResolvedValue([[
-      {
-        propertySummaries: [
-          { displayName: 'a.example', property: 'properties/123' },
-        ],
-      },
-    ]]);
-
-    db.prepare(
-      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
-    db.prepare(
-      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
-
-    const ga4DailyStatus = await getGa4DailyOperationalStatus();
-    const snapshotStatus = await getSnapshotOperationalStatus();
-
-    expect(ga4DailyStatus.state).toBe('stale');
-    expect(ga4DailyStatus.details).toContain('site-a');
-    expect(snapshotStatus.state).toBe('stale');
-    expect(snapshotStatus.details).toContain('GA4');
-  });
-
-  it('surfaces configured-only fallback details when GA4 discovery is unavailable', async () => {
+  it('excludes sites without ga4PropertyId from GA4 daily and snapshot status without live API calls', () => {
     const db = getDb();
     insertSite({ id: 'site-a', domain: 'a.example', searchConsole: false });
     insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456', searchConsole: false });
-    mockListAccountSummaries.mockRejectedValue(new Error('admin unavailable'));
 
     db.prepare(
       'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
@@ -437,7 +408,28 @@ describe('operational status helpers', () => {
       'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
     ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
 
-    const statuses = await getOperationalStatuses();
+    const ga4DailyStatus = getGa4DailyOperationalStatus();
+    const snapshotStatus = getSnapshotOperationalStatus();
+
+    expect(ga4DailyStatus.state).toBe('fresh');
+    expect(ga4DailyStatus.reason).toContain('1 site');
+    expect(snapshotStatus.state).toBe('fresh');
+    expect(mockListAccountSummaries).not.toHaveBeenCalled();
+  });
+
+  it('returns fresh GA4 status using only SQLite-configured properties when GA4 Admin API is unavailable', () => {
+    const db = getDb();
+    insertSite({ id: 'site-a', domain: 'a.example', searchConsole: false });
+    insertSite({ id: 'site-b', name: 'Site B', domain: 'b.example', ga4PropertyId: 'properties/456', searchConsole: false });
+
+    db.prepare(
+      'INSERT INTO ga4_daily (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 11:00:00');
+    db.prepare(
+      'INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('site-b', '2026-05-11', 20, 30, 40, 0.4, 12, '2026-05-12 06:00:00');
+
+    const statuses = getOperationalStatuses();
     const ga4DailyStatus = statuses.find((status) => status.key === 'ga4-daily');
     const snapshotStatus = statuses.find((status) => status.key === 'snapshots');
 
@@ -445,14 +437,10 @@ describe('operational status helpers', () => {
       state: 'fresh',
       reason: 'Collected 1 site through 2026-05-11',
     });
-    expect(ga4DailyStatus?.details).toContain('GA4 discovery unavailable');
-    expect(ga4DailyStatus?.details).toContain('site-a');
-
     expect(snapshotStatus).toMatchObject({
       state: 'fresh',
       reason: 'Latest snapshot date 2026-05-11',
     });
-    expect(snapshotStatus?.details).toContain('GA4 discovery unavailable');
-    expect(snapshotStatus?.details).toContain('site-a');
+    expect(mockListAccountSummaries).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,14 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
 import { computeKeywordDeltas, type KeywordDelta } from './keyword-history';
-import {
-  GA4_DISCOVERY_CACHE_KEY,
-  GA4_DISCOVERY_CACHE_SITE_ID,
-  resolveSiteGa4PropertyId,
-  type DiscoveredGa4Property,
-} from './ga4-discovery';
-import { getAuth } from './google-auth';
 import { openDatabase } from './sqlite-driver.js';
 
 const DB_PATH = path.join(process.cwd(), 'data', 'seo-tools.db');
@@ -456,11 +448,6 @@ interface SourceOperationalSummary {
   hasData: boolean;
 }
 
-interface ResolvedGa4SiteScope {
-  siteIds: string[];
-  discoveryState: 'resolved' | 'configured-only';
-  excludedSiteIds: string[];
-}
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAILY_STATUS_MAX_AGE_MS = 26 * HOUR_MS;
@@ -518,53 +505,6 @@ function getManagedSiteIds(filter: 'all' | 'search-console' | 'ga4'): string[] {
   return (db.prepare(sql).all() as SiteIdRow[]).map((row) => row.id);
 }
 
-async function fetchDiscoveredGa4Properties(): Promise<DiscoveredGa4Property[] | null> {
-  try {
-    const client = new AnalyticsAdminServiceClient({ auth: getAuth() });
-    const [summaries] = await client.listAccountSummaries({});
-    return summaries.flatMap((account) => (
-      (account.propertySummaries ?? []).flatMap((property) => {
-        const displayName = property.displayName?.trim();
-        const propertyId = property.property?.split('/')[1]?.trim();
-        if (!displayName || !propertyId) return [];
-        return [{ displayName, propertyId }];
-      })
-    ));
-  } catch (error) {
-    console.error('[getOperationalStatuses] failed to discover GA4 properties:', error);
-    return null;
-  }
-}
-
-async function getResolvedGa4SiteScope(): Promise<ResolvedGa4SiteScope> {
-  const sites = dbGetSites();
-  const configuredSiteIds = sites
-    .filter((site) => typeof site.ga4PropertyId === 'string' && site.ga4PropertyId.trim() !== '')
-    .map((site) => site.id);
-  const properties = await withCache<DiscoveredGa4Property[]>(
-    GA4_DISCOVERY_CACHE_KEY,
-    GA4_DISCOVERY_CACHE_SITE_ID,
-    fetchDiscoveredGa4Properties,
-  );
-  if (!properties) {
-    return {
-      siteIds: configuredSiteIds,
-      discoveryState: 'configured-only',
-      excludedSiteIds: sites
-        .filter((site) => !(typeof site.ga4PropertyId === 'string' && site.ga4PropertyId.trim() !== ''))
-        .map((site) => site.id),
-    };
-  }
-
-  return {
-    siteIds: sites.flatMap((site) => (
-      resolveSiteGa4PropertyId(site, properties) ? [site.id] : []
-    )),
-    discoveryState: 'resolved',
-    excludedSiteIds: [],
-  };
-}
-
 function getPerSiteDateFreshness(
   table: 'sc_daily' | 'ga4_daily' | 'sc_snapshots' | 'ga4_snapshots',
 ): Map<string, PerSiteDateFreshnessRow> {
@@ -602,20 +542,6 @@ function collectCoverageDetails(missingSites: string[], staleSites: string[]): s
     details.push(`Stale: ${summarizeSites(staleSites)}`);
   }
   return details;
-}
-
-function getGa4DiscoveryFallbackDetail(scope: ResolvedGa4SiteScope): string | null {
-  if (scope.discoveryState !== 'configured-only' || scope.excludedSiteIds.length === 0) {
-    return null;
-  }
-
-  return `GA4 discovery unavailable; excluding sites without saved GA4 property IDs: ${summarizeSites(scope.excludedSiteIds)}`;
-}
-
-function appendStatusDetail(details: string | undefined, extraDetail: string | null): string | undefined {
-  if (!extraDetail) return details;
-  if (!details) return extraDetail;
-  return `${details} · ${extraDetail}`;
 }
 
 function getDailyCollectorStatus(
@@ -691,15 +617,10 @@ export function getScDailyOperationalStatus(): OperationalStatus {
   return getDailyCollectorStatus('sc_daily', 'sc-daily', 'Daily Search Console', 2, 'search-console');
 }
 
-export async function getGa4DailyOperationalStatus(): Promise<OperationalStatus> {
-  const scope = await getResolvedGa4SiteScope();
-  const expectedSiteIds = scope.siteIds;
-  const fallbackDetail = getGa4DiscoveryFallbackDetail(scope);
+export function getGa4DailyOperationalStatus(): OperationalStatus {
+  const expectedSiteIds = getManagedSiteIds('ga4');
   if (expectedSiteIds.length === 0) {
-    return {
-      ...buildNeverStatus('ga4-daily', 'Daily GA4', 'No GA4 sites could be resolved for status checks'),
-      details: fallbackDetail ?? undefined,
-    };
+    return buildNeverStatus('ga4-daily', 'Daily GA4', 'No GA4 property IDs configured');
   }
 
   const latestExpectedDate = localDaysBack(1);
@@ -725,14 +646,11 @@ export async function getGa4DailyOperationalStatus(): Promise<OperationalStatus>
   }
 
   if (populatedRows.length === 0) {
-    return {
-      ...buildNeverStatus(
-        'ga4-daily',
-        'Daily GA4',
-        `No daily rows collected yet for ${pluralizeSites(expectedSiteIds.length)}`,
-      ),
-      details: fallbackDetail ?? undefined,
-    };
+    return buildNeverStatus(
+      'ga4-daily',
+      'Daily GA4',
+      `No daily rows collected yet for ${pluralizeSites(expectedSiteIds.length)}`,
+    );
   }
 
   const latestDate = getLatestDate(populatedRows.map((row) => row.latest_date));
@@ -747,7 +665,7 @@ export async function getGa4DailyOperationalStatus(): Promise<OperationalStatus>
       state: 'fresh',
       timestamp: latestTimestamp,
       reason: `Collected ${pluralizeSites(expectedSiteIds.length)} through ${latestDate}`,
-      details: appendStatusDetail('Collector writes are current', fallbackDetail),
+      details: 'Collector writes are current',
     };
   }
 
@@ -758,7 +676,7 @@ export async function getGa4DailyOperationalStatus(): Promise<OperationalStatus>
     state: 'stale',
     timestamp: latestTimestamp,
     reason: `Expected ${pluralizeSites(expectedSiteIds.length)} through at least ${latestExpectedDate}`,
-    details: appendStatusDetail(detailParts.join(' · '), fallbackDetail),
+    details: detailParts.join(' · '),
   };
 }
 
@@ -829,10 +747,8 @@ export function getSitemapSyncOperationalStatus(): OperationalStatus {
   };
 }
 
-export async function getSnapshotOperationalStatus(): Promise<OperationalStatus> {
+export function getSnapshotOperationalStatus(): OperationalStatus {
   const expectedDate = localDaysBack(1);
-  const ga4Scope = await getResolvedGa4SiteScope();
-  const fallbackDetail = getGa4DiscoveryFallbackDetail(ga4Scope);
   const sources: Array<{
     label: string;
     expectedSiteIds: string[];
@@ -845,16 +761,13 @@ export async function getSnapshotOperationalStatus(): Promise<OperationalStatus>
     },
     {
       label: 'GA4',
-      expectedSiteIds: ga4Scope.siteIds,
+      expectedSiteIds: getManagedSiteIds('ga4'),
       rows: getPerSiteDateFreshness('ga4_snapshots'),
     },
   ].filter((source) => source.expectedSiteIds.length > 0);
 
   if (sources.length === 0) {
-    return {
-      ...buildNeverStatus('snapshots', 'Snapshots', 'No managed snapshot sources configured yet'),
-      details: fallbackDetail ?? undefined,
-    };
+    return buildNeverStatus('snapshots', 'Snapshots', 'No managed snapshot sources configured yet');
   }
 
   const summaries: SourceOperationalSummary[] = sources.map((source) => {
@@ -894,10 +807,7 @@ export async function getSnapshotOperationalStatus(): Promise<OperationalStatus>
 
   const populated = summaries.filter((summary) => summary.hasData);
   if (populated.length === 0) {
-    return {
-      ...buildNeverStatus('snapshots', 'Snapshots', 'No snapshot history recorded yet'),
-      details: fallbackDetail ?? undefined,
-    };
+    return buildNeverStatus('snapshots', 'Snapshots', 'No snapshot history recorded yet');
   }
 
   const latestTimestamp = getLatestTimestamp(populated.map((summary) => summary.latestTimestamp));
@@ -913,7 +823,7 @@ export async function getSnapshotOperationalStatus(): Promise<OperationalStatus>
       state: 'fresh',
       timestamp: latestTimestamp,
       reason: `Latest snapshot date ${latestDate}`,
-      details: appendStatusDetail('SC and GA4 snapshots are current', fallbackDetail),
+      details: 'SC and GA4 snapshots are current',
     };
   }
 
@@ -923,19 +833,16 @@ export async function getSnapshotOperationalStatus(): Promise<OperationalStatus>
     state: 'stale',
     timestamp: latestTimestamp,
     reason: `Latest snapshot date ${latestDate}`,
-    details: appendStatusDetail(
-      `Stale or missing sources: ${staleSources.map((summary) => summary.label).join(', ')}`,
-      fallbackDetail,
-    ),
+    details: `Stale or missing sources: ${staleSources.map((summary) => summary.label).join(', ')}`,
   };
 }
 
-export async function getOperationalStatuses(): Promise<OperationalStatus[]> {
+export function getOperationalStatuses(): OperationalStatus[] {
   return [
     getScDailyOperationalStatus(),
-    await getGa4DailyOperationalStatus(),
+    getGa4DailyOperationalStatus(),
     getSitemapSyncOperationalStatus(),
-    await getSnapshotOperationalStatus(),
+    getSnapshotOperationalStatus(),
   ];
 }
 


### PR DESCRIPTION
Closes #72

---

**Summary:** Fixed issue #72 — removed the live GA4 Admin API dependency from the operational status path by replacing `getResolvedGa4SiteScope()` (which called `withCache` → live Admin API on cold cache) with direct `getManagedSiteIds('ga4')` SQLite reads in `getGa4DailyOperationalStatus()` and `getSnapshotOperationalStatus()`, making both sync and purely SQLite-backed; also commented on #70 which was already resolved by PR #71.

**Files changed:** `src/lib/db.ts`, `app/api/config/operations/route.ts`, `src/lib/__tests__/api-config-operations.test.ts`, `src/lib/__tests__/db.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#72](https://github.com/3h4x/seo-tools/issues/72).