### PR TITLE
fix: Expand audit page sampling so page-level SEO checks cover more than manually listed URLs

### DIFF
--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -197,6 +197,11 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
                       {gapCount} {gapCount === 1 ? 'recommendation' : 'recommendations'}
                     </span>
                   )}
+                  {audit.sampledPages.length > 0 && (
+                    <span className="text-neutral-600 text-[10px] font-medium px-2 py-0.5 rounded-full border border-neutral-800">
+                      {audit.sampledPages.length} {audit.sampledPages.length === 1 ? 'page' : 'pages'} sampled
+                    </span>
+                  )}
                 </div>
                 <div className="flex flex-col items-end gap-1">
                   <span className="text-neutral-600 text-xs">View details →</span>

--- a/src/lib/__tests__/audit-helpers.test.ts
+++ b/src/lib/__tests__/audit-helpers.test.ts
@@ -24,6 +24,9 @@ import {
   parseMetaTags,
   checkImageSeo,
   checkInternalLinks,
+  extractLocsFromSitemap,
+  sampleAuditPages,
+  MAX_SAMPLED_PAGES,
   type FetchResult,
 } from '../audit';
 
@@ -306,5 +309,93 @@ describe('checkInternalLinks', () => {
     const result = checkInternalLinks('<a href="/a">A</a><a href="/b">B</a><a href="/c">C</a>', domain, '/test');
     expect(result.page).toBe('/test');
     expect(result.label).toBe('Internal Links');
+  });
+});
+
+describe('extractLocsFromSitemap', () => {
+  it('extracts loc URLs from urlset sitemap', () => {
+    const xml = `<?xml version="1.0"?><urlset><url><loc>https://example.com/</loc></url><url><loc>https://example.com/about</loc></url></urlset>`;
+    expect(extractLocsFromSitemap(xml)).toEqual(['https://example.com/', 'https://example.com/about']);
+  });
+
+  it('returns empty array for sitemap with no locs', () => {
+    expect(extractLocsFromSitemap('<urlset></urlset>')).toEqual([]);
+  });
+
+  it('trims whitespace from loc values', () => {
+    const xml = `<urlset><url><loc>  https://example.com/page  </loc></url></urlset>`;
+    expect(extractLocsFromSitemap(xml)).toEqual(['https://example.com/page']);
+  });
+});
+
+describe('sampleAuditPages', () => {
+  const domain = 'example.com';
+
+  it('includes testPages in output', () => {
+    const result = sampleAuditPages(['/'], [], [], domain);
+    expect(result).toContain('/');
+  });
+
+  it('deduplicates pages from all sources', () => {
+    const result = sampleAuditPages(
+      ['/'],
+      ['https://example.com/'],
+      ['https://example.com/'],
+      domain,
+    );
+    expect(result).toEqual(['/']);
+  });
+
+  it('adds sitemap locs as paths', () => {
+    const result = sampleAuditPages([], ['https://example.com/about', 'https://example.com/blog'], [], domain);
+    expect(result).toContain('/about');
+    expect(result).toContain('/blog');
+  });
+
+  it('adds SC page paths', () => {
+    const result = sampleAuditPages([], [], ['https://example.com/sc-page'], domain);
+    expect(result).toContain('/sc-page');
+  });
+
+  it('skips locs from other domains', () => {
+    const result = sampleAuditPages([], ['https://other.com/page'], [], domain);
+    expect(result).toEqual([]);
+  });
+
+  it('skips SC pages from other domains', () => {
+    const result = sampleAuditPages([], [], ['https://other.com/page'], domain);
+    expect(result).toEqual([]);
+  });
+
+  it('enforces MAX_SAMPLED_PAGES hard cap', () => {
+    const locs = Array.from({ length: 20 }, (_, i) => `https://example.com/page-${i}`);
+    const result = sampleAuditPages(['/'], locs, [], domain);
+    expect(result.length).toBeLessThanOrEqual(MAX_SAMPLED_PAGES);
+  });
+
+  it('testPages always appear before sitemap/SC pages', () => {
+    const result = sampleAuditPages(
+      ['/manual'],
+      ['https://example.com/sitemap-page'],
+      ['https://example.com/sc-page'],
+      domain,
+    );
+    expect(result[0]).toBe('/manual');
+  });
+
+  it('caps sitemap sample to 5 pages', () => {
+    const locs = Array.from({ length: 10 }, (_, i) => `https://example.com/s-${i}`);
+    const result = sampleAuditPages([], locs, [], domain);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it('caps SC sample to 5 pages', () => {
+    const scUrls = Array.from({ length: 10 }, (_, i) => `https://example.com/sc-${i}`);
+    const result = sampleAuditPages([], [], scUrls, domain);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    expect(() => sampleAuditPages([], ['not-a-url'], ['also-bad'], domain)).not.toThrow();
   });
 });

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -45,6 +45,7 @@ function makeAudit(overrides: Partial<SiteAuditResult> = {}): SiteAuditResult {
       favicon: makeCheckResult('pass', 'Favicon'),
     },
     score: { pass: 20, warn: 0, fail: 0, error: 0, total: 20 },
+    sampledPages: ['/'],
     ...overrides,
   };
 }

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -243,6 +243,7 @@ function makeAuditResult() {
       favicon: makeCheckResult({ label: 'Favicon' }),
     },
     score: { pass: 5, warn: 1, fail: 0, error: 0, total: 6 },
+    sampledPages: ['/'],
   };
 }
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -24,6 +24,7 @@ interface SitemapResult extends CheckResult {
   isIndex?: boolean;
   hasLastmod?: boolean;
   lastmodSample?: string;
+  locs?: string[];
 }
 
 interface MetaTagResult {
@@ -116,6 +117,60 @@ export interface SiteAuditResult {
   internalLinks: InternalLinkResult[];
   security: SecurityResult;
   score: { pass: number; warn: number; fail: number; error: number; total: number };
+  sampledPages: string[];
+}
+
+export const MAX_SAMPLED_PAGES = 10;
+const SITEMAP_SAMPLE_LIMIT = 5;
+const SC_SAMPLE_LIMIT = 5;
+
+export function extractLocsFromSitemap(xml: string): string[] {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/gi)].map(m => m[1].trim());
+}
+
+export function sampleAuditPages(
+  testPages: string[],
+  sitemapLocs: string[],
+  scPageUrls: string[],
+  domain: string,
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const addPath = (path: string) => {
+    if (seen.has(path) || result.length >= MAX_SAMPLED_PAGES) return false;
+    seen.add(path);
+    result.push(path);
+    return true;
+  };
+
+  for (const p of testPages) {
+    addPath(p.startsWith('/') ? p : `/${p}`);
+  }
+
+  let sitemapAdded = 0;
+  for (const loc of sitemapLocs) {
+    if (sitemapAdded >= SITEMAP_SAMPLE_LIMIT || result.length >= MAX_SAMPLED_PAGES) break;
+    try {
+      const url = new URL(loc);
+      if (url.hostname !== domain) continue;
+      const path = url.pathname + (url.search || '');
+      if (addPath(path)) sitemapAdded++;
+    } catch { /* skip invalid URLs */ }
+  }
+
+  let scAdded = 0;
+  for (const page of scPageUrls) {
+    if (scAdded >= SC_SAMPLE_LIMIT || result.length >= MAX_SAMPLED_PAGES) break;
+    try {
+      const url = new URL(page);
+      if (url.hostname !== domain) continue;
+      const path = url.pathname + (url.search || '');
+      if (addPath(path)) scAdded++;
+    } catch { /* skip invalid URLs */ }
+  }
+
+  return result;
 }
 
 function getSc() {
@@ -227,17 +282,18 @@ async function checkSitemap(domain: string, sitemapUrl?: string): Promise<Sitema
       fresh = Date.now() - d.getTime() < 30 * 24 * 60 * 60 * 1000;
     }
 
+    const locs = isIndex ? [] : extractLocsFromSitemap(res.text);
     const countLabel = isIndex ? `${urlCount} child sitemaps` : `${urlCount} URLs`;
     const lastmodMsg = hasLastmod ? (fresh ? `, latest: ${mostRecent}` : `, stale lastmod: ${mostRecent}`) : ', no lastmod';
 
     if (urlCount === 0) {
-      return { status: 'warn', label: 'Sitemap', message: `Found at ${url} but empty`, url, urlCount: 0, isIndex };
+      return { status: 'warn', label: 'Sitemap', message: `Found at ${url} but empty`, url, urlCount: 0, isIndex, locs: [] };
     }
 
     return {
       status: hasLastmod && !fresh ? 'warn' : 'pass',
       label: 'Sitemap', message: `${countLabel}${lastmodMsg}`,
-      url, urlCount, isIndex, hasLastmod, lastmodSample: mostRecent,
+      url, urlCount, isIndex, hasLastmod, lastmodSample: mostRecent, locs,
     };
   }
 
@@ -709,22 +765,54 @@ async function checkIndexingCoverage(site: Site, sitemapUrlCount?: number): Prom
   }
 }
 
+async function fetchScTopPageUrls(site: Site): Promise<string[]> {
+  if (!site.searchConsole) return [];
+  try {
+    const scUrl = getSCUrl(site);
+    const formattedUrl = scUrl.startsWith('sc-domain:') || scUrl.startsWith('http') ? scUrl : `sc-domain:${scUrl}`;
+    const end = new Date();
+    end.setDate(end.getDate() - 1);
+    const start = new Date();
+    start.setDate(start.getDate() - 30);
+    const res = await getSc().searchanalytics.query({
+      siteUrl: formattedUrl,
+      requestBody: {
+        startDate: start.toISOString().split('T')[0],
+        endDate: end.toISOString().split('T')[0],
+        dimensions: ['page'],
+        rowLimit: SC_SAMPLE_LIMIT * 2,
+      },
+    });
+    return (res.data.rows || []).map(r => r.keys?.[0] || '').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 async function auditSite(site: Site): Promise<SiteAuditResult> {
   const robotsTxt = await checkRobotsTxt(site.domain);
 
-  const [sitemap, ttfb, security, scSitemapFreshness] = await Promise.all([
+  const [sitemap, ttfb, security, scSitemapFreshness, scTopPageUrls] = await Promise.all([
     checkSitemap(site.domain, robotsTxt.sitemapUrl),
     checkTtfb(site.domain),
     checkSecurity(site.domain),
     checkScSitemapFreshness(site),
+    fetchScTopPageUrls(site),
   ]);
+
+  const sampledPages = sampleAuditPages(
+    site.testPages,
+    sitemap.locs ?? [],
+    scTopPageUrls,
+    site.domain,
+  );
 
   // Indexing coverage: compare sitemap URLs vs pages in search results
   const indexingCoverage = await checkIndexingCoverage(site, sitemap.urlCount);
 
-  // Fetch test pages sequentially to avoid rate-limiting
+  // Fetch sampled pages sequentially to avoid rate-limiting
   const pageResults: { meta: MetaTagResult; images: ImageSeoResult; links: InternalLinkResult }[] = [];
-  for (const page of site.testPages) {
+  for (const page of sampledPages) {
     const res = await safeFetch(`https://${site.domain}${page}`, { ua: GOOGLEBOT_UA });
     const meta = parseMetaTags(res, page);
     if (res.ok) {
@@ -810,6 +898,7 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     internalLinks: skippedInternalLinks,
     security: skippedSecurity,
     score,
+    sampledPages,
   };
 }
 


### PR DESCRIPTION
Closes #35

All 518 tests pass. Now update the memory file:
---

- **Summary**: Implemented issue #35 — audit page sampling now derives candidate URLs from `testPages`, sitemap `<loc>` tags (up to 5), and top SC pages (up to 5), merges/dedupes them, and caps at 10 pages per site; sampled page count is shown as a badge on the `/audit` cards.
- **Files changed**: `src/lib/audit.ts`, `src/lib/__tests__/audit-helpers.test.ts`, `src/lib/__tests__/gaps.test.ts`, `src/lib/__tests__/trends-page.test.tsx`, `app/audit/page.tsx`
- **Actionable work**: yes

---
Implemented via TamTam from issue [#35](https://github.com/3h4x/seo-tools/issues/35).