### PR TITLE
fix: Surface per-page top queries from SC so content-intent mismatch is visible without leaving the dashboard

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -7,7 +7,6 @@ import { discoverPropertyIds, cachedGetAnalytics } from '@/lib/ga4';
 import {
   cachedGetSearchConsoleDataWithComparison,
   cachedGetSearchConsoleQueries,
-  cachedGetSearchConsolePages,
   cachedGetSitemapSubmissions,
 } from '@/lib/search-console';
 import { cachedAuditSite } from '@/lib/audit';
@@ -25,6 +24,7 @@ import { MetricCard } from '../components/metric-card';
 import { CheckCard, statusDots, Recommendation, MetaChecksTable } from '../components/audit/check-card';
 import { gapsBySection } from '@/lib/gaps';
 import { ScTable } from '../components/sc-table';
+import { PageQueriesTable } from '../components/page-queries-table';
 import { VALID_DAYS } from '@/lib/constants';
 
 export const revalidate = 300;
@@ -84,12 +84,11 @@ export default async function SiteDashboardPage({
 
   const scUrl = getSCUrl(site);
 
-  const [audit, sitemapSubmissions, scComparison, scQueries, scPages, ga4Data, cwvSummary] = await Promise.all([
+  const [audit, sitemapSubmissions, scComparison, scQueries, ga4Data, cwvSummary] = await Promise.all([
     cachedAuditSite(site),
     site.searchConsole ? cachedGetSitemapSubmissions(scUrl) : Promise.resolve([]),
     site.searchConsole ? cachedGetSearchConsoleDataWithComparison(scUrl, days) : null,
     site.searchConsole ? cachedGetSearchConsoleQueries(scUrl, days) : null,
-    site.searchConsole ? cachedGetSearchConsolePages(scUrl, days) : null,
     cachedGetAnalytics(propertyId, days),
     getCwvAuditSummary(siteId),
   ]);
@@ -254,18 +253,7 @@ export default async function SiteDashboardPage({
           exportData={(scQueries ?? []).map(r => ({ query: r.query, clicks: r.clicks, impressions: r.impressions, ctr: `${(r.ctr * 100).toFixed(2)}%`, position: r.position.toFixed(1) }))}
           filename={`${siteId}-queries-${days}d`}
         />
-        <ScTable
-          heading="Top Pages (Search Console)"
-          columnLabel="Page"
-          rows={(scPages ?? []).map(r => {
-            let label = r.page;
-            try { label = new URL(r.page).pathname; } catch {}
-            return { label, title: r.page, clicks: r.clicks, impressions: r.impressions, position: r.position };
-          })}
-          emptyMessage="No page data available."
-          exportData={(scPages ?? []).map(r => ({ page: r.page, clicks: r.clicks, impressions: r.impressions, position: r.position.toFixed(1) }))}
-          filename={`${siteId}-pages-${days}d`}
-        />
+        <PageQueriesTable siteId={siteId} days={days} />
       </div>
       {keywordDeltas.length > 0 && (
         <div>

--- a/app/api/[site]/page-queries/route.ts
+++ b/app/api/[site]/page-queries/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getManagedSite, getSCUrl } from '@/lib/sites';
+import { cachedGetTopPagesWithQueries } from '@/lib/search-console';
+import { VALID_DAYS } from '@/lib/constants';
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ site: string }> },
+) {
+  try {
+    const { site } = await context.params;
+    const rawDays = parseInt(req.nextUrl.searchParams.get('days') || '7');
+    const days = VALID_DAYS.includes(rawDays) ? rawDays : 7;
+
+    const siteConfig = await getManagedSite(site);
+    if (!siteConfig) {
+      return NextResponse.json({ error: 'Site not found' }, { status: 404 });
+    }
+
+    if (!siteConfig.searchConsole) {
+      return NextResponse.json({ data: [] });
+    }
+
+    const scUrl = getSCUrl(siteConfig);
+    const data = await cachedGetTopPagesWithQueries(scUrl, days);
+    return NextResponse.json({ data: data ?? [] });
+  } catch (error) {
+    console.error('Error fetching page queries:', error);
+    return NextResponse.json({ error: 'Failed to fetch page queries' }, { status: 500 });
+  }
+}

--- a/app/components/page-queries-table.tsx
+++ b/app/components/page-queries-table.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { PositionBadge } from './position-badge';
+import type { SCQueryRow, PageQueryResult } from '@/lib/search-console';
+
+interface PageQueriesTableProps {
+  siteId: string;
+  days: number;
+}
+
+export function PageQueriesTable({ siteId, days }: PageQueriesTableProps) {
+  const [rows, setRows] = useState<PageQueryResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/${siteId}/page-queries?days=${days}`)
+      .then((r) => r.json())
+      .then((body) => setRows(body.data ?? []))
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false));
+  }, [siteId, days]);
+
+  function toggle(page: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(page)) {
+        next.delete(page);
+      } else {
+        next.add(page);
+      }
+      return next;
+    });
+  }
+
+  function pathname(url: string) {
+    try { return new URL(url).pathname; } catch { return url; }
+  }
+
+  return (
+    <div>
+      <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">
+        Top Pages (Search Console)
+      </h2>
+      {loading ? (
+        <p className="text-neutral-600 text-sm">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-neutral-600 text-sm">No page data available.</p>
+      ) : (
+        <div className="bg-neutral-900 rounded-lg border border-neutral-800 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-800 text-neutral-500 text-xs uppercase tracking-wider">
+                <th className="px-4 py-3 font-semibold text-left">Page</th>
+                <th className="px-4 py-3 font-semibold text-right">Clicks</th>
+                <th className="px-4 py-3 font-semibold text-right hidden md:table-cell">Impr</th>
+                <th className="px-4 py-3 font-semibold text-right">Pos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const isOpen = expanded.has(row.page);
+                return (
+                  <React.Fragment key={row.page}>
+                    <tr
+                      className="hover:bg-neutral-800/30 transition-colors cursor-pointer border-b border-neutral-800/50 last:border-0"
+                      onClick={() => toggle(row.page)}
+                    >
+                      <td className="px-4 py-2.5 text-neutral-300 text-xs truncate max-w-[200px]">
+                        <span className="inline-flex items-center gap-1.5">
+                          <span className={`transition-transform text-neutral-600 text-[10px] ${isOpen ? 'rotate-90' : ''}`}>▶</span>
+                          <span title={row.page}>{pathname(row.page)}</span>
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-neutral-300 text-right">{row.clicks.toLocaleString()}</td>
+                      <td className="px-4 py-2.5 text-neutral-400 text-right hidden md:table-cell">{row.impressions.toLocaleString()}</td>
+                      <td className="px-4 py-2.5 text-right">
+                        <PositionBadge position={row.position} />
+                      </td>
+                    </tr>
+                    {isOpen && (
+                      <tr key={`${row.page}-expanded`} className="bg-neutral-950/50">
+                        <td colSpan={4} className="px-6 pb-3 pt-1">
+                          {row.queries.length === 0 ? (
+                            <p className="text-neutral-600 text-xs">No query data for this page.</p>
+                          ) : (
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr className="text-neutral-600 uppercase tracking-wider">
+                                  <th className="py-1 text-left font-medium">Query</th>
+                                  <th className="py-1 text-right font-medium">Clicks</th>
+                                  <th className="py-1 text-right font-medium hidden md:table-cell">Impr</th>
+                                  <th className="py-1 text-right font-medium hidden md:table-cell">CTR</th>
+                                  <th className="py-1 text-right font-medium">Pos</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {row.queries.map((q: SCQueryRow) => (
+                                  <tr key={q.query} className="border-t border-neutral-800/30">
+                                    <td className="py-1 text-neutral-400 truncate max-w-[180px]">{q.query}</td>
+                                    <td className="py-1 text-neutral-400 text-right">{q.clicks.toLocaleString()}</td>
+                                    <td className="py-1 text-neutral-500 text-right hidden md:table-cell">{q.impressions.toLocaleString()}</td>
+                                    <td className="py-1 text-neutral-500 text-right hidden md:table-cell">{(q.ctr * 100).toFixed(1)}%</td>
+                                    <td className="py-1 text-right"><PositionBadge position={q.position} /></td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/api-page-queries.test.ts
+++ b/src/lib/__tests__/api-page-queries.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('../sites', () => ({
+  getManagedSite: vi.fn(),
+  getSCUrl: vi.fn(),
+}));
+
+vi.mock('../search-console', () => ({
+  cachedGetTopPagesWithQueries: vi.fn(),
+}));
+
+vi.mock('../constants', () => ({
+  VALID_DAYS: [7, 28, 90],
+}));
+
+import { getManagedSite, getSCUrl } from '../sites';
+import { cachedGetTopPagesWithQueries } from '../search-console';
+import { GET } from '../../../app/api/[site]/page-queries/route';
+
+function getReq(url = 'http://localhost/api/borged-io/page-queries'): NextRequest {
+  return new NextRequest(url);
+}
+
+const fakeSite = { id: 'borged-io', name: 'Borged', domain: 'borged.io', searchConsole: true };
+const fakeData = [
+  {
+    page: 'https://borged.io/posts/hello',
+    clicks: 42,
+    impressions: 800,
+    ctr: 0.0525,
+    position: 4.2,
+    queries: [
+      { query: 'hello world', clicks: 10, impressions: 200, ctr: 0.05, position: 4.2 },
+    ],
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSCUrl).mockReturnValue('sc-domain:borged.io');
+});
+
+describe('GET /api/[site]/page-queries', () => {
+  it('returns page query data for a known site', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(fakeSite as any);
+    vi.mocked(cachedGetTopPagesWithQueries).mockResolvedValueOnce(fakeData);
+
+    const res = await GET(getReq(), { params: Promise.resolve({ site: 'borged-io' }) });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(cachedGetTopPagesWithQueries)).toHaveBeenCalledWith('sc-domain:borged.io', 7);
+    expect(await res.json()).toEqual({ data: fakeData });
+  });
+
+  it('respects the days query param', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(fakeSite as any);
+    vi.mocked(cachedGetTopPagesWithQueries).mockResolvedValueOnce(fakeData);
+
+    const res = await GET(getReq('http://localhost/api/borged-io/page-queries?days=28'), {
+      params: Promise.resolve({ site: 'borged-io' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(cachedGetTopPagesWithQueries)).toHaveBeenCalledWith('sc-domain:borged.io', 28);
+  });
+
+  it('falls back to 7 days for an invalid days param', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(fakeSite as any);
+    vi.mocked(cachedGetTopPagesWithQueries).mockResolvedValueOnce([]);
+
+    await GET(getReq('http://localhost/api/borged-io/page-queries?days=999'), {
+      params: Promise.resolve({ site: 'borged-io' }),
+    });
+
+    expect(vi.mocked(cachedGetTopPagesWithQueries)).toHaveBeenCalledWith('sc-domain:borged.io', 7);
+  });
+
+  it('returns 404 when the site does not exist', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(null);
+
+    const res = await GET(getReq(), { params: Promise.resolve({ site: 'missing' }) });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Site not found' });
+  });
+
+  it('returns empty data when site has no Search Console config', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce({ ...fakeSite, searchConsole: false } as any);
+
+    const res = await GET(getReq(), { params: Promise.resolve({ site: 'borged-io' }) });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+    expect(vi.mocked(cachedGetTopPagesWithQueries)).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when lib returns null', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(fakeSite as any);
+    vi.mocked(cachedGetTopPagesWithQueries).mockResolvedValueOnce(null);
+
+    const res = await GET(getReq(), { params: Promise.resolve({ site: 'borged-io' }) });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+  });
+
+  it('returns 500 when the lib throws', async () => {
+    vi.mocked(getManagedSite).mockResolvedValueOnce(fakeSite as any);
+    vi.mocked(cachedGetTopPagesWithQueries).mockRejectedValueOnce(new Error('SC unavailable'));
+
+    const res = await GET(getReq(), { params: Promise.resolve({ site: 'borged-io' }) });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to fetch page queries' });
+  });
+});

--- a/src/lib/__tests__/search-console.test.ts
+++ b/src/lib/__tests__/search-console.test.ts
@@ -23,6 +23,7 @@ import {
   cachedGetSearchConsoleQueries,
   cachedGetSearchConsolePages,
   cachedGetSitemapSubmissions,
+  cachedGetTopPagesWithQueries,
 } from '../search-console';
 
 beforeEach(() => {
@@ -366,5 +367,84 @@ describe('cachedGetSitemapSubmissions', () => {
     await cachedGetSitemapSubmissions('https://example.com/');
 
     expect(mockSitemapsList).toHaveBeenCalledWith({ siteUrl: 'https://example.com/' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cachedGetTopPagesWithQueries
+// ---------------------------------------------------------------------------
+
+describe('cachedGetTopPagesWithQueries', () => {
+  it('propagates page-level aggregates from the SC pages query into each result', async () => {
+    // First call: getSearchConsolePages (dimensions: ['page'])
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        rows: [
+          { keys: ['https://example.com/foo'], clicks: 120, impressions: 2400, ctr: 0.05, position: 3.1 },
+        ],
+      },
+    });
+    // Second call: getQueriesForPage for /foo
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        rows: [
+          { keys: ['best foo'], clicks: 40, impressions: 800, ctr: 0.05, position: 2.9 },
+        ],
+      },
+    });
+
+    const result = await cachedGetTopPagesWithQueries('example.com', 7);
+
+    expect(result).toHaveLength(1);
+    expect(result![0].page).toBe('https://example.com/foo');
+    expect(result![0].clicks).toBe(120);
+    expect(result![0].impressions).toBe(2400);
+    expect(result![0].ctr).toBe(0.05);
+    expect(result![0].position).toBe(3.1);
+    expect(result![0].queries).toHaveLength(1);
+    expect(result![0].queries[0].query).toBe('best foo');
+  });
+
+  it('returns null when the underlying pages query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('API error'));
+
+    const result = await cachedGetTopPagesWithQueries('example.com', 7);
+
+    expect(result).toBeNull();
+  });
+
+  it('slices to at most 10 pages', async () => {
+    const manyRows = Array.from({ length: 15 }, (_, i) => ({
+      keys: [`https://example.com/page-${i}`],
+      clicks: 10,
+      impressions: 200,
+      ctr: 0.05,
+      position: 5.0,
+    }));
+    mockQuery.mockResolvedValueOnce({ data: { rows: manyRows } });
+    // Return empty queries for each of the 10 pages
+    for (let i = 0; i < 10; i++) {
+      mockQuery.mockResolvedValueOnce({ data: { rows: [] } });
+    }
+
+    const result = await cachedGetTopPagesWithQueries('example.com', 7);
+
+    expect(result).toHaveLength(10);
+  });
+
+  it('handles pages with no query data gracefully', async () => {
+    mockQuery.mockResolvedValueOnce({
+      data: {
+        rows: [{ keys: ['https://example.com/bar'], clicks: 5, impressions: 50, ctr: 0.1, position: 8.0 }],
+      },
+    });
+    // Query fetch for the page fails silently
+    mockQuery.mockRejectedValueOnce(new Error('quota'));
+
+    const result = await cachedGetTopPagesWithQueries('example.com', 7);
+
+    expect(result).toHaveLength(1);
+    expect(result![0].clicks).toBe(5);
+    expect(result![0].queries).toEqual([]);
   });
 });

--- a/src/lib/search-console.ts
+++ b/src/lib/search-console.ts
@@ -48,12 +48,21 @@ interface SCAggregates {
   position: number;
 }
 
-interface SCQueryRow {
+export interface SCQueryRow {
   query: string;
   clicks: number;
   impressions: number;
   ctr: number;
   position: number;
+}
+
+export interface PageQueryResult {
+  page: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+  queries: SCQueryRow[];
 }
 
 export interface SCPageRow {
@@ -172,6 +181,73 @@ export async function getSearchConsolePagesForPeriod(
   rowLimit: number = 100,
 ): Promise<SCPageRow[] | null> {
   return queryScPages(siteUrl, startDate, endDate, rowLimit);
+}
+
+// --- Per-page query breakdown ---
+
+async function getQueriesForPage(
+  siteUrl: string,
+  pageUrl: string,
+  days: number,
+): Promise<SCQueryRow[]> {
+  try {
+    const response = await getSc().searchanalytics.query({
+      siteUrl: formatSiteUrl(siteUrl),
+      requestBody: {
+        startDate: daysAgo(days),
+        endDate: daysAgo(1),
+        dimensions: ['query'],
+        rowLimit: 5,
+        dimensionFilterGroups: [{
+          filters: [{
+            dimension: 'page',
+            operator: 'equals',
+            expression: pageUrl,
+          }],
+        }],
+      },
+    });
+    return (response.data.rows || []).map((row) => ({
+      query: row.keys?.[0] || '',
+      clicks: row.clicks || 0,
+      impressions: row.impressions || 0,
+      ctr: row.ctr || 0,
+      position: row.position || 0,
+    }));
+  } catch (error) {
+    console.error(`Error fetching SC queries for page ${pageUrl}:`, error);
+    return [];
+  }
+}
+
+async function getTopPagesWithQueries(
+  siteUrl: string,
+  days: number = 7,
+): Promise<PageQueryResult[] | null> {
+  const pages = await getSearchConsolePages(siteUrl, days);
+  if (!pages) return null;
+  const top = pages.slice(0, 10);
+  const results = await Promise.all(
+    top.map(async (p) => ({
+      page: p.page,
+      clicks: p.clicks,
+      impressions: p.impressions,
+      ctr: p.ctr,
+      position: p.position,
+      queries: await getQueriesForPage(siteUrl, p.page, days),
+    })),
+  );
+  return results;
+}
+
+export async function cachedGetTopPagesWithQueries(
+  siteUrl: string,
+  days: number = 7,
+) {
+  return withCache<PageQueryResult[]>(
+    `sc-page-queries-${days}`, siteUrl,
+    () => getTopPagesWithQueries(siteUrl, days),
+  );
 }
 
 // --- Sitemap submissions ---


### PR DESCRIPTION
Closes #33

**Summary:** Implemented issue #33 — per-page top queries from Search Console — on branch `fix/issue-33-surface-per-page-top-queries-from-sc-so`.

**Files changed:** `src/lib/search-console.ts`, `app/api/[site]/page-queries/route.ts`, `app/components/page-queries-table.tsx`, `app/[site]/page.tsx`, `src/lib/__tests__/api-page-queries.test.ts`

**Actionable work:** yes

---
Implemented via TamTam from issue [#33](https://github.com/3h4x/seo-tools/issues/33).