### PR TITLE
fix: Track TTFB per snapshot so performance regressions surface automatically

### DIFF
--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -5,6 +5,7 @@ import {
   getScTrends,
   getGa4Trends,
   getAuditTrends,
+  getTtfbTrends,
   getSnapshotCount,
   getKeywordCount,
   getTopKeywordsWithHistory,
@@ -122,17 +123,19 @@ function OverviewTab({
     const scTrends = getScTrends(site.id);
     const ga4Trends = getGa4Trends(site.id);
     const auditTrends = getAuditTrends(site.id);
+    const ttfbTrends = getTtfbTrends(site.id);
     const latestGa4 = ga4Trends[ga4Trends.length - 1];
     const latestSc = scTrends[scTrends.length - 1];
-    return { site, scTrends, ga4Trends, auditTrends, latestGa4, latestSc };
+    const latestTtfb = ttfbTrends[ttfbTrends.length - 1];
+    return { site, scTrends, ga4Trends, auditTrends, ttfbTrends, latestGa4, latestSc, latestTtfb };
   }).sort((a, b) => (b.latestGa4?.users ?? 0) - (a.latestGa4?.users ?? 0));
 
   return (
     <div>
       <h2 className="text-xs uppercase tracking-wider text-neutral-500 mb-3 font-semibold">Per-Site Data</h2>
       <div className="space-y-4">
-        {sitesData.map(({ site, scTrends, ga4Trends, auditTrends, latestGa4, latestSc }) => {
-          const hasData = scTrends.length > 0 || ga4Trends.length > 0 || auditTrends.length > 0;
+        {sitesData.map(({ site, scTrends, ga4Trends, auditTrends, ttfbTrends, latestGa4, latestSc, latestTtfb }) => {
+          const hasData = scTrends.length > 0 || ga4Trends.length > 0 || auditTrends.length > 0 || ttfbTrends.length > 0;
 
           if (!hasData) {
             return (
@@ -169,7 +172,10 @@ function OverviewTab({
                       <MetricCell label="SC Position" value={latestSc.position.toFixed(1)} color="text-neutral-300" />
                     </>
                   )}
-                  {!latestGa4 && !latestSc && (
+                  {latestTtfb && (
+                    <MetricCell label="TTFB" value={`${latestTtfb.ttfbMs}ms`} color="text-orange-400" />
+                  )}
+                  {!latestGa4 && !latestSc && !latestTtfb && (
                     <div className="col-span-full text-neutral-600 text-sm">No metrics available</div>
                   )}
                 </div>
@@ -211,6 +217,17 @@ function OverviewTab({
                   </div>
                 )}
               </div>
+              {ttfbTrends.length > 0 && (
+                <div>
+                  <h3 className="text-neutral-500 text-xs uppercase tracking-wider mb-3 font-semibold">TTFB · ms · lower is better</h3>
+                  <TrendChart
+                    data={ttfbTrends}
+                    lines={[{ key: 'ttfbMs', color: '#f97316', label: 'TTFB (ms)' }]}
+                    height={160}
+                    valueFormat="integer"
+                  />
+                </div>
+              )}
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
                 {ga4Trends.length > 0 && (
                   <TrendsTable
@@ -274,6 +291,21 @@ function OverviewTab({
                       <span key="p" className="text-emerald-400">{row.pass}</span>,
                       <span key="w" className="text-amber-400">{row.warn}</span>,
                       <span key="f" className="text-red-400">{row.fail}</span>,
+                    ])}
+                  />
+                )}
+                {ttfbTrends.length > 0 && (
+                  <TrendsTable
+                    title="TTFB"
+                    columns={[
+                      { label: 'Date' },
+                      { label: 'ms', align: 'right' },
+                    ]}
+                    rows={ttfbTrends.map((row) => [
+                      <span key="d" className="text-neutral-400">{row.date}</span>,
+                      <span key="t" className={row.ttfbMs < 800 ? 'text-emerald-400' : row.ttfbMs < 2000 ? 'text-amber-400' : 'text-red-400'}>
+                        {row.ttfbMs}ms
+                      </span>,
                     ])}
                   />
                 )}

--- a/src/lib/__tests__/snapshot.test.ts
+++ b/src/lib/__tests__/snapshot.test.ts
@@ -47,13 +47,17 @@ vi.mock('@google-analytics/data', () => ({
 
 import { getDb } from '../db';
 import { runSnapshot } from '../snapshot';
-import { getScTrends, getGa4Trends } from '../db';
+import { getScTrends, getGa4Trends, getTtfbTrends } from '../db';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 function resetDb() {
   const db = getDb();
   db.exec(`
     DELETE FROM sc_snapshots;
     DELETE FROM ga4_snapshots;
+    DELETE FROM audit_snapshots;
     DELETE FROM keyword_history;
   `);
 }
@@ -61,6 +65,7 @@ function resetDb() {
 beforeEach(() => {
   resetDb();
   vi.clearAllMocks();
+  fetchMock.mockResolvedValue({ ok: true, status: 200 });
 
   // SC returns a page-dimension query and a query-dimension query in order per site.
   scQueryMock.mockImplementation(async ({ requestBody }: { requestBody: { dimensions: string[] } }) => {
@@ -107,5 +112,49 @@ describe('runSnapshot dedupe', () => {
     const ga4ForToday = ga4Trend.filter((p) => p.date === today);
     expect(ga4ForToday).toHaveLength(1);
     expect(ga4ForToday[0]?.users).toBe(10);
+  });
+});
+
+describe('runSnapshot TTFB', () => {
+  it('writes ttfb_ms to audit_snapshots for each site', async () => {
+    const result = await runSnapshot();
+    expect(result.ttfb).toBe(2);
+
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT site_id, ttfb_ms FROM audit_snapshots WHERE date = ? ORDER BY site_id',
+    ).all(result.date) as Array<{ site_id: string; ttfb_ms: number }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].site_id).toBe('site-a');
+    expect(rows[0].ttfb_ms).toBeGreaterThanOrEqual(0);
+    expect(rows[1].site_id).toBe('site-b');
+  });
+
+  it('deduplicates audit_snapshots on re-run', async () => {
+    await runSnapshot();
+    const r2 = await runSnapshot();
+
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT site_id FROM audit_snapshots WHERE date = ? ORDER BY site_id',
+    ).all(r2.date) as Array<{ site_id: string }>;
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it('getTtfbTrends returns stored TTFB data', async () => {
+    const result = await runSnapshot();
+    const trends = getTtfbTrends('site-a');
+    expect(trends).toHaveLength(1);
+    expect(trends[0].date).toBe(result.date);
+    expect(trends[0].ttfbMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records TTFB fetch error and continues other sites', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const result = await runSnapshot();
+    expect(result.errors.some((e) => e.includes('TTFB site-a'))).toBe(true);
+    expect(result.ttfb).toBe(1); // site-b still succeeds
   });
 });

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -23,6 +23,7 @@ const {
   mockGetScTrends,
   mockGetGa4Trends,
   mockGetAuditTrends,
+  mockGetTtfbTrends,
   mockGetTopKeywordsWithHistory,
   mockGetKeywordDeltas,
   mockGetScDaily,
@@ -37,6 +38,7 @@ const {
   mockGetScTrends: vi.fn(),
   mockGetGa4Trends: vi.fn(),
   mockGetAuditTrends: vi.fn(),
+  mockGetTtfbTrends: vi.fn(),
   mockGetTopKeywordsWithHistory: vi.fn(),
   mockGetKeywordDeltas: vi.fn(),
   mockGetScDaily: vi.fn(),
@@ -55,6 +57,7 @@ vi.mock('@/lib/db', () => ({
   getScTrends: mockGetScTrends,
   getGa4Trends: mockGetGa4Trends,
   getAuditTrends: mockGetAuditTrends,
+  getTtfbTrends: mockGetTtfbTrends,
   getTopKeywordsWithHistory: mockGetTopKeywordsWithHistory,
   getKeywordDeltas: mockGetKeywordDeltas,
   getScDaily: mockGetScDaily,
@@ -281,6 +284,7 @@ beforeEach(() => {
   mockGetAuditTrends.mockReturnValue([
     { date: '2026-05-02', pass: 7, warn: 1, fail: 0 },
   ]);
+  mockGetTtfbTrends.mockReturnValue([]);
   mockGetTopKeywordsWithHistory.mockReturnValue({
     topQueries: ['seo tools'],
     history: [

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -162,6 +162,7 @@ function initSchema(db: SqliteDatabase): void {
   `);
   // Migrations for existing DBs
   try { db.exec(`ALTER TABLE sites ADD COLUMN color TEXT`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN ttfb_ms INTEGER`); } catch { /* already exists */ }
 }
 
 // --- Cache helpers ---
@@ -327,6 +328,22 @@ export function getAuditTrends(siteId: string, limit: number = 90): AuditTrendPo
     warn: r.warn_count,
     fail: r.fail_count,
   }));
+}
+
+export interface TtfbTrendPoint {
+  date: string;
+  ttfbMs: number;
+}
+
+export function getTtfbTrends(siteId: string, limit: number = 90): TtfbTrendPoint[] {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT date, ttfb_ms
+    FROM audit_snapshots WHERE site_id = ? AND ttfb_ms IS NOT NULL
+    ORDER BY date DESC LIMIT ?
+  `).all(siteId, limit) as Array<{ date: string; ttfb_ms: number }>;
+
+  return rows.reverse().map(r => ({ date: r.date, ttfbMs: r.ttfb_ms }));
 }
 
 // --- Daily SC/GA4 helpers ---

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -10,6 +10,7 @@ export interface SnapshotResult {
   sc: number;
   keywords: number;
   ga4: number;
+  ttfb: number;
   errors: string[];
 }
 
@@ -45,7 +46,7 @@ async function doSnapshot(): Promise<SnapshotResult> {
 
   const sites = await discoverPropertyIds();
   if (sites.length === 0) {
-    return { date: today, sc: 0, keywords: 0, ga4: 0, errors: ['No sites configured'] };
+    return { date: today, sc: 0, keywords: 0, ga4: 0, ttfb: 0, errors: ['No sites configured'] };
   }
 
   const sc = new searchconsole_v1.Searchconsole({ auth: getAuth() });
@@ -154,5 +155,28 @@ async function doSnapshot(): Promise<SnapshotResult> {
     }
   }
 
-  return { date: today, sc: scCount, keywords: kwCount, ga4: ga4Count, errors };
+  const auditDelete = db.prepare('DELETE FROM audit_snapshots WHERE site_id = ? AND date = ?');
+  const auditInsert = db.prepare(
+    'INSERT INTO audit_snapshots (site_id, date, pass_count, warn_count, fail_count, checks_json, ttfb_ms) VALUES (?, ?, 0, 0, 0, ?, ?)',
+  );
+  let ttfbCount = 0;
+  for (const site of sites) {
+    try {
+      const start = Date.now();
+      await fetch(`https://${site.domain}/`, {
+        signal: AbortSignal.timeout(10_000),
+        method: 'HEAD',
+      });
+      const ttfbMs = Date.now() - start;
+      db.transaction(() => {
+        auditDelete.run(site.id, today);
+        auditInsert.run(site.id, today, '{}', ttfbMs);
+      })();
+      ttfbCount++;
+    } catch (e) {
+      errors.push(`TTFB ${site.id}: ${String(e).slice(0, 80)}`);
+    }
+  }
+
+  return { date: today, sc: scCount, keywords: kwCount, ga4: ga4Count, ttfb: ttfbCount, errors };
 }


### PR DESCRIPTION
Closes #26

---

**Summary:** Implemented issue #26 — each snapshot run now measures TTFB via a HEAD request per site, stores it in `audit_snapshots.ttfb_ms`, and surfaces it on the Trends page as both an orange area chart and a color-coded table (green <800ms, amber <2000ms, red ≥2000ms).

**Files changed:** `src/lib/db.ts`, `src/lib/snapshot.ts`, `app/trends/page.tsx`, `src/lib/__tests__/snapshot.test.ts`, `src/lib/__tests__/trends-page.test.tsx`

**Actionable work:** yes

---
Implemented via TamTam from issue [#26](https://github.com/3h4x/seo-tools/issues/26).