### PR TITLE
fix: Add SERP snippet preview to audit so title/description truncation is visible before Google shows it

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -379,6 +379,14 @@ export default async function SiteDashboardPage({
                   <MetaChecksTable
                     checks={[meta.title, meta.description, meta.ogTitle, meta.ogImage, meta.ogDescription, meta.twitterCard, meta.canonical, meta.jsonLd]}
                   />
+                  <SerpSnippetPreview
+                    page={meta.page}
+                    domain={site.domain}
+                    titleRaw={meta.title.rawValue}
+                    titleLen={meta.title.rawLength}
+                    descRaw={meta.description.rawValue}
+                    descLen={meta.description.rawLength}
+                  />
                 </div>
               ))}
             </div>
@@ -566,6 +574,61 @@ function AuditPanel({ title, children }: { title: string; children: ReactNode })
     <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-5">
       <h2 className="text-white font-semibold text-sm mb-4">{title}</h2>
       {children}
+    </div>
+  );
+}
+
+function SerpSnippetPreview({ page, domain, titleRaw, titleLen, descRaw, descLen }: {
+  page: string;
+  domain: string;
+  titleRaw: string | undefined;
+  titleLen: number | undefined;
+  descRaw: string | undefined;
+  descLen: number | undefined;
+}) {
+  const TITLE_LIMIT = 60;
+  const DESC_LIMIT = 160;
+  const breadcrumb = `${domain}${page === '/' ? '' : page}`;
+  return (
+    <div className="mt-3 border border-neutral-700/40 rounded bg-neutral-800/20 p-3">
+      <div className="text-[10px] text-neutral-500 uppercase tracking-wider mb-2 font-semibold">SERP Preview</div>
+      <div className="max-w-xl">
+        <div className="text-[11px] text-green-700 font-mono mb-0.5 truncate">{breadcrumb}</div>
+        <div className="text-[15px] leading-snug mb-1">
+          {titleRaw ? (
+            <>
+              <span className="text-blue-400">{titleRaw.slice(0, TITLE_LIMIT)}</span>
+              {(titleLen ?? 0) > TITLE_LIMIT && (
+                <span className="text-red-400/50 line-through">{titleRaw.slice(TITLE_LIMIT, TITLE_LIMIT + 15)}&hellip;</span>
+              )}
+            </>
+          ) : (
+            <span className="text-neutral-600 italic text-sm">No title</span>
+          )}
+        </div>
+        <div className="text-[12px] text-neutral-400 leading-relaxed">
+          {descRaw ? (
+            <>
+              <span>{descRaw.slice(0, DESC_LIMIT)}</span>
+              {(descLen ?? 0) > DESC_LIMIT && <span className="text-amber-400/60">&hellip;</span>}
+            </>
+          ) : (
+            <span className="text-neutral-600 italic">No meta description</span>
+          )}
+        </div>
+        <div className="flex gap-4 mt-1.5 text-[10px] font-mono text-neutral-600">
+          {titleLen !== undefined && (
+            <span className={titleLen > TITLE_LIMIT ? 'text-red-400' : titleLen > 50 ? 'text-amber-400' : ''}>
+              title {titleLen}/{TITLE_LIMIT}
+            </span>
+          )}
+          {descLen !== undefined && (
+            <span className={descLen < 70 ? 'text-red-400' : descLen < 120 ? 'text-amber-400' : descLen > DESC_LIMIT ? 'text-red-400' : ''}>
+              desc {descLen}/{DESC_LIMIT}
+            </span>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -10,6 +10,8 @@ export interface CheckResult {
   label: string;
   message: string;
   details?: string;
+  rawLength?: number;
+  rawValue?: string;
 }
 
 interface RobotsTxtResult extends CheckResult {
@@ -310,8 +312,8 @@ export function extractMeta(html: string, property: string, attr: string = 'prop
 
 export function makeCheck(label: string, value: string | null, minLen: number = 1): CheckResult {
   if (!value) return { status: 'fail', label, message: 'Not found' };
-  if (value.length < minLen) return { status: 'warn', label, message: `Found but too short: "${value}"` };
-  return { status: 'pass', label, message: value.length > 80 ? value.slice(0, 77) + '...' : value };
+  if (value.length < minLen) return { status: 'warn', label, message: `Found but too short: "${value}"`, rawLength: value.length, rawValue: value };
+  return { status: 'pass', label, message: value.length > 80 ? value.slice(0, 77) + '...' : value, rawLength: value.length, rawValue: value };
 }
 
 const GENERIC_TITLES = ['react app', 'vite app', 'document', 'untitled', 'home', 'index'];
@@ -338,8 +340,8 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   const titleCheck: CheckResult = !titleVal
     ? { status: 'fail', label: 'title', message: 'Not found' }
     : GENERIC_TITLES.includes(titleVal.toLowerCase())
-      ? { status: 'warn', label: 'title', message: `Generic title: "${titleVal}"` }
-      : { status: 'pass', label: 'title', message: titleVal.length > 80 ? titleVal.slice(0, 77) + '...' : titleVal };
+      ? { status: 'warn', label: 'title', message: `Generic title: "${titleVal}"`, rawLength: titleVal.length, rawValue: titleVal }
+      : { status: 'pass', label: 'title', message: titleVal.length > 80 ? titleVal.slice(0, 77) + '...' : titleVal, rawLength: titleVal.length, rawValue: titleVal };
 
   const desc = extractMeta(html, 'description', 'name');
   const ogTitle = extractMeta(html, 'og:title');


### PR DESCRIPTION
Closes #32

**Summary:** Implemented issue #32 — added a SERP snippet preview to the per-site audit page, showing a Google-style result card (URL breadcrumb, title with 60-char truncation indicator, description with 160-char limit) below each page's meta tag check table.

**Files changed:** `src/lib/audit.ts`, `app/[site]/page.tsx`

**Actionable work:** yes

---
Implemented via TamTam from issue [#32](https://github.com/3h4x/seo-tools/issues/32).