### PR TITLE
fix: Add per-site SC and GA4 diagnostics in Config so broken access is visible before dashboards go blank

### DIFF
--- a/app/api/config/site-diagnostics/route.ts
+++ b/app/api/config/site-diagnostics/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getSiteDiagnostics } from '@/lib/site-diagnostics';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const diagnostics = await getSiteDiagnostics();
+    return NextResponse.json(
+      { diagnostics },
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    );
+  } catch (error) {
+    console.error('[GET /api/config/site-diagnostics]', error);
+    return NextResponse.json({ error: 'failed_to_load_site_diagnostics' }, { status: 500 });
+  }
+}

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { applyImportResults, buildImportSummary, getImportResult, type DiscoverySite, type ImportResult, type ImportSummary } from '@/lib/discovery-import';
 import { getSiteScUrlOverride, isValidSiteDomain, isValidSiteId, normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
+import type { SiteDiagnosticResult } from '@/lib/site-diagnostics';
 import { SKIP_CHECK_OPTIONS, hasSkipCheck, toggleSkipCheck } from '@/lib/skip-checks';
 
 interface Site {
@@ -46,8 +47,48 @@ function moveItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
   return next;
 }
 
+function buildDiagnosticMap(diagnostics: SiteDiagnosticResult[]): Record<string, SiteDiagnosticResult> {
+  return Object.fromEntries(diagnostics.map((diagnostic) => [diagnostic.siteId, diagnostic]));
+}
+
+async function fetchSiteDiagnostics(): Promise<Record<string, SiteDiagnosticResult>> {
+  const res = await fetch('/api/config/site-diagnostics', { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('diagnostics');
+  }
+
+  const data = await res.json() as { diagnostics: SiteDiagnosticResult[] };
+  return buildDiagnosticMap(data.diagnostics);
+}
+
+function StatusBadge({
+  status,
+  message,
+}: {
+  status: SiteDiagnosticResult['searchConsole']['status'] | 'loading';
+  message: string;
+}) {
+  const styles = {
+    ok: 'border-emerald-800/80 bg-emerald-950/50 text-emerald-300',
+    'missing-config': 'border-neutral-700 bg-neutral-900 text-neutral-400',
+    'permission-error': 'border-red-900/80 bg-red-950/40 text-red-300',
+    'not-found': 'border-amber-900/80 bg-amber-950/40 text-amber-300',
+    'provider-error': 'border-red-900/80 bg-red-950/40 text-red-300',
+    loading: 'border-neutral-700 bg-neutral-900 text-neutral-500',
+  } as const;
+
+  return (
+    <span className={`inline-flex items-center rounded border px-2 py-0.5 text-[11px] font-medium ${styles[status]}`}>
+      {message}
+    </span>
+  );
+}
+
 export default function SitesManager({ initialSites, hasAuth }: Props) {
   const [sites, setSites] = useState<Site[]>(initialSites);
+  const [diagnostics, setDiagnostics] = useState<Record<string, SiteDiagnosticResult>>({});
+  const [diagnosticsLoading, setDiagnosticsLoading] = useState(false);
+  const [diagnosticsError, setDiagnosticsError] = useState(false);
   const [editMode, setEditMode] = useState<EditMode>('none');
   const [form, setForm] = useState<Site>({ id: '', ...EMPTY_SITE });
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
@@ -77,11 +118,36 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     setError('');
   }
 
+  const loadDiagnostics = useCallback(async () => {
+    if (!hasAuth) {
+      setDiagnostics({});
+      setDiagnosticsError(false);
+      setDiagnosticsLoading(false);
+      return;
+    }
+
+    setDiagnosticsLoading(true);
+    try {
+      setDiagnostics(await fetchSiteDiagnostics());
+      setDiagnosticsError(false);
+    } catch {
+      setDiagnostics({});
+      setDiagnosticsError(true);
+    } finally {
+      setDiagnosticsLoading(false);
+    }
+  }, [hasAuth]);
+
   async function reloadSites() {
     const res = await fetch('/api/sites');
     const data = await res.json() as Site[];
     setSites(data);
+    await loadDiagnostics();
   }
+
+  useEffect(() => {
+    void loadDiagnostics();
+  }, [loadDiagnostics]);
 
   async function persistSiteOrder(nextSites: Site[]) {
     const previousSites = sites;
@@ -289,7 +355,9 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                 <th className="py-2 pr-4 font-medium">Name</th>
                 <th className="py-2 pr-4 font-medium">Domain</th>
                 <th className="py-2 pr-4 font-medium">Search Console</th>
+                <th className="py-2 pr-4 font-medium">SC Access</th>
                 <th className="py-2 pr-4 font-medium">GA4</th>
+                <th className="py-2 pr-4 font-medium">GA4 Access</th>
                 <th className="py-2 font-medium"></th>
               </tr>
             </thead>
@@ -325,7 +393,41 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                   </td>
                   <td className="py-2 pr-4 text-neutral-400 font-mono text-xs">{site.domain}</td>
                   <td className="py-2 pr-4 text-neutral-400">{site.searchConsole ? '✓' : '–'}</td>
+                  <td className="py-2 pr-4">
+                    {hasAuth ? (
+                      diagnostics[site.id] ? (
+                        <StatusBadge
+                          status={diagnostics[site.id].searchConsole.status}
+                          message={diagnostics[site.id].searchConsole.message}
+                        />
+                      ) : (
+                        <StatusBadge
+                          status={diagnosticsLoading ? 'loading' : 'provider-error'}
+                          message={diagnosticsLoading ? 'Checking…' : 'Unavailable'}
+                        />
+                      )
+                    ) : (
+                      <StatusBadge status="loading" message="No service account" />
+                    )}
+                  </td>
                   <td className="py-2 pr-4 text-neutral-400">{site.ga4PropertyId ? '✓' : '–'}</td>
+                  <td className="py-2 pr-4">
+                    {hasAuth ? (
+                      diagnostics[site.id] ? (
+                        <StatusBadge
+                          status={diagnostics[site.id].ga4.status}
+                          message={diagnostics[site.id].ga4.message}
+                        />
+                      ) : (
+                        <StatusBadge
+                          status={diagnosticsLoading ? 'loading' : 'provider-error'}
+                          message={diagnosticsLoading ? 'Checking…' : 'Unavailable'}
+                        />
+                      )
+                    ) : (
+                      <StatusBadge status="loading" message="No service account" />
+                    )}
+                  </td>
                   <td className="py-2 flex gap-2">
                     <button
                       onClick={() => startEdit(site)}
@@ -364,6 +466,9 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
             </tbody>
           </table>
         </div>
+      )}
+      {diagnosticsError && hasAuth && (
+        <p className="text-xs text-red-400">Could not load per-site diagnostics.</p>
       )}
       {isEditing && (
         <div className="border border-neutral-700 rounded-lg p-4 space-y-4 bg-neutral-900/50">

--- a/src/lib/__tests__/site-diagnostics.test.ts
+++ b/src/lib/__tests__/site-diagnostics.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockScSitesGet,
+  mockGa4RunReport,
+  mockGetManagedSites,
+  mockGetSCUrl,
+} = vi.hoisted(() => ({
+  mockScSitesGet: vi.fn(),
+  mockGa4RunReport: vi.fn(),
+  mockGetManagedSites: vi.fn(),
+  mockGetSCUrl: vi.fn((site: { scUrl?: string; domain: string }) => site.scUrl ?? `sc-domain:${site.domain}`),
+}));
+
+vi.mock('../google-auth', () => ({ getAuth: () => ({}) }));
+vi.mock('@googleapis/searchconsole', () => ({
+  searchconsole_v1: {
+    Searchconsole: class {
+      sites = { get: mockScSitesGet };
+    },
+  },
+}));
+vi.mock('@google-analytics/data', () => ({
+  BetaAnalyticsDataClient: class {
+    runReport = mockGa4RunReport;
+  },
+}));
+vi.mock('../sites', () => ({
+  getManagedSites: mockGetManagedSites,
+  getSCUrl: mockGetSCUrl,
+}));
+
+import { getSiteDiagnostics } from '../site-diagnostics';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getSiteDiagnostics', () => {
+  it('returns ok statuses when both providers are accessible', async () => {
+    mockGetManagedSites.mockResolvedValue([
+      {
+        id: 'site-a',
+        name: 'Site A',
+        domain: 'example.com',
+        searchConsole: true,
+        ga4PropertyId: 'properties/123',
+        testPages: ['/'],
+      },
+    ]);
+    mockScSitesGet.mockResolvedValue({});
+    mockGa4RunReport.mockResolvedValue([{}]);
+
+    const result = await getSiteDiagnostics();
+
+    expect(result).toEqual([
+      {
+        siteId: 'site-a',
+        searchConsole: { status: 'ok', message: 'Accessible' },
+        ga4: { status: 'ok', message: 'Accessible' },
+      },
+    ]);
+    expect(mockScSitesGet).toHaveBeenCalledWith({ siteUrl: 'sc-domain:example.com' });
+    expect(mockGa4RunReport).toHaveBeenCalledWith(expect.objectContaining({ property: 'properties/123' }));
+  });
+
+  it('returns missing-config when provider config is absent', async () => {
+    mockGetManagedSites.mockResolvedValue([
+      {
+        id: 'site-b',
+        name: 'Site B',
+        domain: 'missing.com',
+        searchConsole: false,
+        testPages: ['/'],
+      },
+    ]);
+
+    const result = await getSiteDiagnostics();
+
+    expect(result).toEqual([
+      {
+        siteId: 'site-b',
+        searchConsole: { status: 'missing-config', message: 'Disabled for this site' },
+        ga4: { status: 'missing-config', message: 'No GA4 property ID' },
+      },
+    ]);
+    expect(mockScSitesGet).not.toHaveBeenCalled();
+    expect(mockGa4RunReport).not.toHaveBeenCalled();
+  });
+
+  it('classifies permission and not-found provider failures', async () => {
+    mockGetManagedSites.mockResolvedValue([
+      {
+        id: 'site-c',
+        name: 'Site C',
+        domain: 'broken.com',
+        searchConsole: true,
+        ga4PropertyId: 'properties/999',
+        testPages: ['/'],
+      },
+    ]);
+    mockScSitesGet.mockRejectedValue({ code: 403, message: 'The caller does not have permission' });
+    mockGa4RunReport.mockRejectedValue({ code: 404, message: 'Requested entity was not found' });
+
+    const result = await getSiteDiagnostics();
+
+    expect(result).toEqual([
+      {
+        siteId: 'site-c',
+        searchConsole: { status: 'permission-error', message: 'Permission error' },
+        ga4: { status: 'not-found', message: 'Not found' },
+      },
+    ]);
+  });
+
+  it('classifies string-based provider statuses from Google clients', async () => {
+    mockGetManagedSites.mockResolvedValue([
+      {
+        id: 'site-d',
+        name: 'Site D',
+        domain: 'strings.test',
+        searchConsole: true,
+        ga4PropertyId: 'properties/321',
+        testPages: ['/'],
+      },
+    ]);
+    mockScSitesGet.mockRejectedValue({ status: 'PERMISSION_DENIED', message: 'insufficient permissions' });
+    mockGa4RunReport.mockRejectedValue({ code: 'NOT_FOUND', message: 'resource missing' });
+
+    const result = await getSiteDiagnostics();
+
+    expect(result).toEqual([
+      {
+        siteId: 'site-d',
+        searchConsole: { status: 'permission-error', message: 'Permission error' },
+        ga4: { status: 'not-found', message: 'Not found' },
+      },
+    ]);
+  });
+});

--- a/src/lib/site-diagnostics.ts
+++ b/src/lib/site-diagnostics.ts
@@ -1,0 +1,132 @@
+import { searchconsole_v1 } from '@googleapis/searchconsole';
+import { BetaAnalyticsDataClient } from '@google-analytics/data';
+import { getAuth } from './google-auth';
+import { getManagedSites, getSCUrl, type Site } from './sites';
+
+export type DiagnosticStatus = 'ok' | 'missing-config' | 'permission-error' | 'not-found' | 'provider-error';
+
+export interface ProviderDiagnostic {
+  status: DiagnosticStatus;
+  message: string;
+}
+
+export interface SiteDiagnosticResult {
+  siteId: string;
+  searchConsole: ProviderDiagnostic;
+  ga4: ProviderDiagnostic;
+}
+
+function getSearchConsoleClient() {
+  return new searchconsole_v1.Searchconsole({ auth: getAuth() });
+}
+
+function getGa4Client() {
+  return new BetaAnalyticsDataClient({ auth: getAuth() });
+}
+
+function normalizeErrorCode(value: unknown): number | string | null {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const numeric = Number(trimmed);
+  if (Number.isInteger(numeric)) {
+    return numeric;
+  }
+
+  return trimmed.toUpperCase();
+}
+
+function classifyProviderError(error: unknown): ProviderDiagnostic {
+  const details = error as { code?: unknown; status?: unknown; message?: unknown };
+  const code = normalizeErrorCode(details.code) ?? normalizeErrorCode(details.status);
+  const message = typeof details.message === 'string'
+    ? details.message
+    : error instanceof Error
+      ? error.message
+      : 'Unknown provider error';
+  const normalizedMessage = message.toLowerCase();
+
+  if (
+    code === 403
+    || code === 'PERMISSION_DENIED'
+    || code === 'FORBIDDEN'
+    || normalizedMessage.includes('forbidden')
+    || normalizedMessage.includes('permission')
+    || normalizedMessage.includes('not authorized')
+    || normalizedMessage.includes('insufficient permission')
+    || normalizedMessage.includes('access denied')
+  ) {
+    return { status: 'permission-error', message: 'Permission error' };
+  }
+
+  if (
+    code === 404
+    || code === 'NOT_FOUND'
+    || normalizedMessage.includes('not found')
+    || normalizedMessage.includes('requested entity was not found')
+  ) {
+    return { status: 'not-found', message: 'Not found' };
+  }
+
+  return { status: 'provider-error', message: 'Provider error' };
+}
+
+async function checkSearchConsoleAccess(site: Site): Promise<ProviderDiagnostic> {
+  if (site.searchConsole === false) {
+    return { status: 'missing-config', message: 'Disabled for this site' };
+  }
+
+  try {
+    await getSearchConsoleClient().sites.get({ siteUrl: getSCUrl(site) });
+    return { status: 'ok', message: 'Accessible' };
+  } catch (error) {
+    return classifyProviderError(error);
+  }
+}
+
+async function checkGa4Access(site: Site): Promise<ProviderDiagnostic> {
+  if (!site.ga4PropertyId) {
+    return { status: 'missing-config', message: 'No GA4 property ID' };
+  }
+
+  try {
+    await getGa4Client().runReport({
+      property: site.ga4PropertyId,
+      dateRanges: [{ startDate: 'yesterday', endDate: 'yesterday' }],
+      metrics: [{ name: 'activeUsers' }],
+      limit: 1,
+    });
+    return { status: 'ok', message: 'Accessible' };
+  } catch (error) {
+    return classifyProviderError(error);
+  }
+}
+
+export async function getSiteDiagnostics(): Promise<SiteDiagnosticResult[]> {
+  const sites = await getManagedSites();
+
+  return Promise.all(
+    sites.map(async (site) => {
+      const [searchConsole, ga4] = await Promise.all([
+        checkSearchConsoleAccess(site),
+        checkGa4Access(site),
+      ]);
+
+      return {
+        siteId: site.id,
+        searchConsole,
+        ga4,
+      };
+    }),
+  );
+}


### PR DESCRIPTION
Closes #37

Skipped already-fixed `#70`, implemented `#37`, commented on the issue, created the TamTam issue branch, and added per-site Config diagnostics for SC and GA4.

---
Implemented via TamTam from issue [#37](https://github.com/3h4x/seo-tools/issues/37).