### PR TITLE
fix: Discover GA4-only properties so analytics-only sites can be onboarded from Config

### DIFF
--- a/app/api/sites/discover/route.ts
+++ b/app/api/sites/discover/route.ts
@@ -4,7 +4,8 @@ import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { dbGetSites } from '@/lib/db';
 import { cachedGetDiscoveredGa4Properties } from '@/lib/ga4';
 import { normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
-import { getSCUrl, type Site } from '@/lib/sites';
+import { getSearchConsoleUrlIdentities, getSiteSearchConsoleIdentities, normalizeSearchConsoleIdentity, type Site } from '@/lib/sites';
+import { buildUniqueExactGa4Matches, findMatchingGa4Property, type DiscoveredGa4Property } from '@/lib/ga4-discovery';
 
 type DiscoveredScSite = {
   scUrl: string;
@@ -15,9 +16,18 @@ type DedupeScSite = DiscoveredScSite & {
   scUrls: string[];
 };
 
-function normalizeScIdentity(value: string): string {
-  return value.trim().toLowerCase().replace(/\/$/, '');
-}
+type DiscoverySource = 'sc' | 'ga4' | 'sc+ga4';
+
+type DiscoveryCandidate = Site & {
+  isUpdate?: boolean;
+  discoverySource: DiscoverySource;
+  ga4DisplayName?: string;
+};
+
+type MatchedGa4Property = {
+  propertyId: string;
+  displayName: string;
+};
 
 function isDomainProperty(scUrl: string): boolean {
   return scUrl.toLowerCase().startsWith('sc-domain:');
@@ -37,7 +47,7 @@ function shouldPreferScSite(candidate: DiscoveredScSite, current: DiscoveredScSi
   const candidateRank = getScSiteRank(candidate);
   const currentRank = getScSiteRank(current);
   if (candidateRank !== currentRank) return candidateRank > currentRank;
-  return normalizeScIdentity(candidate.scUrl) < normalizeScIdentity(current.scUrl);
+  return normalizeSearchConsoleIdentity(candidate.scUrl) < normalizeSearchConsoleIdentity(current.scUrl);
 }
 
 function dedupeScSites(scSites: DiscoveredScSite[]): DedupeScSite[] {
@@ -62,6 +72,43 @@ function getExistingDomainIdentity(domain: string): string {
   return normalizeSiteDomain(domain) ?? domain.trim().toLowerCase();
 }
 
+function normalizeGa4PropertyId(propertyId: string): string | undefined {
+  const trimmed = propertyId.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith('properties/') ? trimmed : `properties/${trimmed}`;
+}
+
+function toMatchedGa4Property(property: DiscoveredGa4Property | undefined): MatchedGa4Property | undefined {
+  if (!property) return undefined;
+
+  const propertyId = normalizeGa4PropertyId(property.propertyId);
+  const displayName = property.displayName.trim();
+  if (!propertyId || !displayName) return undefined;
+
+  return {
+    propertyId,
+    displayName,
+  };
+}
+
+function createDiscoveryIdAllocator(existingIds: Iterable<string>): (domain: string) => string {
+  const reservedIds = new Set(existingIds);
+
+  return (domain: string): string => {
+    const baseId = slugifySiteDomain(domain);
+    let nextId = baseId;
+    let suffix = 2;
+
+    while (reservedIds.has(nextId)) {
+      nextId = `${baseId}-${suffix}`;
+      suffix += 1;
+    }
+
+    reservedIds.add(nextId);
+    return nextId;
+  };
+}
+
 export async function GET(req: Request) {
   let auth;
   try {
@@ -71,8 +118,9 @@ export async function GET(req: Request) {
   }
 
   const existingSites = dbGetSites();
+  const existingSiteIds = new Set(existingSites.map(site => site.id));
   const existingDomains = new Set(existingSites.map(s => getExistingDomainIdentity(s.domain)));
-  const existingScIdentities = new Set(existingSites.map(s => normalizeScIdentity(getSCUrl(s))));
+  const existingScIdentities = new Set(existingSites.flatMap(getSiteSearchConsoleIdentities));
 
   // Fetch SC sites
   let scSites: DedupeScSite[] = [];
@@ -94,57 +142,94 @@ export async function GET(req: Request) {
   }
 
   // Fetch GA4 properties (best-effort)
-  const ga4Map = new Map<string, string>(); // display name → propertyId
+  let ga4Properties: DiscoveredGa4Property[] | null = null;
   try {
-    const properties = await cachedGetDiscoveredGa4Properties();
-    for (const property of properties ?? []) {
-      const displayName = property.displayName.trim().toLowerCase();
-      const propertyId = property.propertyId.trim();
-      if (displayName && propertyId) ga4Map.set(displayName, propertyId);
-    }
+    ga4Properties = await cachedGetDiscoveredGa4Properties();
   } catch {
     // GA4 discovery is best-effort; proceed without it.
   }
 
+  const exactGa4Matches = buildUniqueExactGa4Matches(ga4Properties ?? []);
+  const allocateDiscoveryId = createDiscoveryIdAllocator(existingSiteIds);
+
   // Debug: return raw GA4 property names
   if (new URL(req.url).searchParams.has('ga4debug')) {
-    return NextResponse.json(Object.fromEntries(ga4Map));
+    return NextResponse.json(Object.fromEntries(
+      (ga4Properties ?? [])
+        .map((property) => {
+          const propertyId = property.propertyId.trim();
+          const displayName = property.displayName.trim().toLowerCase();
+          return displayName && propertyId ? [displayName, propertyId] : null;
+        })
+        .filter((entry): entry is [string, string] => entry !== null),
+    ));
   }
 
-  function matchGa4(domain: string): string | undefined {
-    const domainLower = domain.toLowerCase();
-    for (const [name, propId] of ga4Map.entries()) {
-      if (name.includes(domainLower) || domainLower.includes(name)) {
-        // Return in properties/NNNNNN format so it passes site validation on import
-        return propId.startsWith('properties/') ? propId : `properties/${propId}`;
+  // Build proposed sites from the union of SC domains and GA4 properties not already in DB
+  const proposedFromSc: DiscoveryCandidate[] = scSites
+    .filter(({ domain, scUrls }) => {
+      if (existingDomains.has(domain.toLowerCase()) || existingScIdentities.has(domain.toLowerCase())) {
+        return false;
       }
-    }
-    return undefined;
-  }
 
-  // Build proposed sites from SC domains not already in DB
-  const proposed: (Site & { isUpdate?: boolean })[] = scSites
-    .filter(({ domain, scUrls }) => (
-      !existingDomains.has(domain.toLowerCase()) &&
-      scUrls.every(scUrl => !existingScIdentities.has(normalizeScIdentity(scUrl)))
-    ))
-    .map(({ domain, scUrl }) => ({
-      id: slugifySiteDomain(domain),
+      const scIdentities = new Set<string>([domain.toLowerCase()]);
+      for (const scUrl of scUrls) {
+        for (const identity of getSearchConsoleUrlIdentities(scUrl)) {
+          scIdentities.add(identity);
+        }
+      }
+
+      return [...scIdentities].every(identity => !existingScIdentities.has(identity));
+    })
+    .map(({ domain, scUrl }) => {
+      const ga4Match = toMatchedGa4Property(findMatchingGa4Property(domain, ga4Properties ?? []));
+      return {
+        id: allocateDiscoveryId(domain),
+        name: domain,
+        domain,
+        scUrl: /^https?:\/\//i.test(scUrl) ? scUrl : undefined,
+        searchConsole: true,
+        testPages: ['/'],
+        ga4PropertyId: ga4Match?.propertyId,
+        ga4DisplayName: ga4Match?.displayName,
+        discoverySource: ga4Match ? 'sc+ga4' : 'sc',
+      };
+    });
+  const proposedScDomains = new Set(proposedFromSc.map(site => site.domain));
+  const proposed: DiscoveryCandidate[] = [...proposedFromSc];
+
+  for (const [domain, ga4Match] of exactGa4Matches.entries()) {
+    if (proposedScDomains.has(domain) || existingDomains.has(domain) || existingScIdentities.has(domain)) continue;
+
+    const matchedGa4Property = toMatchedGa4Property(ga4Match);
+    if (!matchedGa4Property) continue;
+
+    proposed.push({
+      id: allocateDiscoveryId(domain),
       name: domain,
       domain,
-      scUrl: /^https?:\/\//i.test(scUrl) ? scUrl : undefined,
-      searchConsole: true,
+      searchConsole: false,
       testPages: ['/'],
-      ga4PropertyId: matchGa4(domain),
-    }));
+      ga4PropertyId: matchedGa4Property.propertyId,
+      ga4DisplayName: matchedGa4Property.displayName,
+      discoverySource: 'ga4',
+    });
+  }
 
   // Backfill existing sites that are missing a GA4 property ID but now have a discovered match
-  const backfill: (Site & { isUpdate: boolean })[] = existingSites
+  const scDomains = new Set(scSites.map(site => site.domain));
+  const backfill: DiscoveryCandidate[] = existingSites
     .filter(site => !site.ga4PropertyId)
     .flatMap(site => {
-      const ga4PropertyId = matchGa4(site.domain);
-      if (!ga4PropertyId) return [];
-      return [{ ...site, ga4PropertyId, isUpdate: true }];
+      const ga4Match = toMatchedGa4Property(findMatchingGa4Property(site.domain, ga4Properties ?? []));
+      if (!ga4Match) return [];
+      return [{
+        ...site,
+        ga4PropertyId: ga4Match.propertyId,
+        ga4DisplayName: ga4Match.displayName,
+        discoverySource: scDomains.has(site.domain.toLowerCase()) ? 'sc+ga4' : 'ga4',
+        isUpdate: true,
+      }];
     });
 
   return NextResponse.json([...proposed, ...backfill]);

--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -19,6 +19,13 @@ interface Site {
   isUpdate?: boolean;
 }
 
+type DiscoverySource = 'sc' | 'ga4' | 'sc+ga4';
+
+type DiscoveredSite = DiscoverySite<Site> & {
+  discoverySource: DiscoverySource;
+  ga4DisplayName?: string;
+};
+
 interface Props {
   initialSites: Site[];
   hasAuth: boolean;
@@ -84,6 +91,20 @@ function StatusBadge({
   );
 }
 
+function DiscoverySourceBadge({ source }: { source: DiscoverySource }) {
+  const styles = {
+    sc: 'border-sky-900/80 bg-sky-950/40 text-sky-300',
+    ga4: 'border-emerald-900/80 bg-emerald-950/40 text-emerald-300',
+    'sc+ga4': 'border-violet-900/80 bg-violet-950/40 text-violet-300',
+  } as const;
+
+  return (
+    <span className={`text-xs rounded border px-1.5 py-0.5 ${styles[source]}`}>
+      {source === 'sc+ga4' ? 'SC + GA4' : source.toUpperCase()}
+    </span>
+  );
+}
+
 export default function SitesManager({ initialSites, hasAuth }: Props) {
   const [sites, setSites] = useState<Site[]>(initialSites);
   const [diagnostics, setDiagnostics] = useState<Record<string, SiteDiagnosticResult>>({});
@@ -93,7 +114,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
   const [form, setForm] = useState<Site>({ id: '', ...EMPTY_SITE });
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [discovering, setDiscovering] = useState(false);
-  const [discovered, setDiscovered] = useState<DiscoverySite<Site>[] | null>(null);
+  const [discovered, setDiscovered] = useState<DiscoveredSite[] | null>(null);
   const [discoverError, setDiscoverError] = useState('');
   const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -204,7 +225,10 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
       const res = await fetch('/api/sites', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(siteToSave),
+        body: JSON.stringify({
+          ...siteToSave,
+          originalId: editMode === 'new' ? undefined : form.id,
+        }),
       });
       const data = await res.json() as { ok: boolean; error?: string };
       if (!data.ok) {
@@ -245,7 +269,7 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     setSelected(new Set());
     try {
       const res = await fetch('/api/sites/discover');
-      const data = await res.json() as Site[] | { error: string };
+      const data = await res.json() as DiscoveredSite[] | { error: string };
       if ('error' in data) {
         setDiscoverError(data.error);
       } else {
@@ -285,11 +309,20 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
     try {
       const results = await Promise.all(toImport.map(async (site): Promise<ImportResult> => {
         try {
-          const { importError: _importError, isUpdate: _isUpdate, ...siteToSave } = site;
+          const {
+            importError: _importError,
+            isUpdate: _isUpdate,
+            discoverySource: _discoverySource,
+            ga4DisplayName: _ga4DisplayName,
+            ...siteToSave
+          } = site;
           const res = await fetch('/api/sites', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(siteToSave),
+            body: JSON.stringify({
+              ...siteToSave,
+              originalId: site.isUpdate ? site.id : undefined,
+            }),
           });
           return {
             id: site.id,
@@ -663,10 +696,21 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
                         {site.isUpdate && (
                           <span className="text-xs text-amber-400 border border-amber-700 rounded px-1">update</span>
                         )}
-                        {site.ga4PropertyId && (
-                          <span className="text-xs text-neutral-500">GA4: {site.ga4PropertyId}</span>
-                        )}
+                        <DiscoverySourceBadge source={site.discoverySource} />
                       </label>
+                      <div className="pl-6 space-y-1 text-xs text-neutral-500">
+                        {site.ga4PropertyId ? (
+                          <p>
+                            GA4 match: {site.ga4PropertyId}
+                            {site.ga4DisplayName ? ` · ${site.ga4DisplayName}` : ''}
+                          </p>
+                        ) : (
+                          <p>No GA4 property match yet.</p>
+                        )}
+                        {site.discoverySource === 'ga4' && (
+                          <p>Search Console match missing. Import and set the SC property manually if needed.</p>
+                        )}
+                      </div>
                       {site.importError && (
                         <p className="pl-6 text-xs text-red-400">{site.importError}</p>
                       )}

--- a/src/lib/__tests__/api-discover.test.ts
+++ b/src/lib/__tests__/api-discover.test.ts
@@ -121,6 +121,166 @@ describe('GET /api/sites/discover', () => {
     const res = await GET(getReq());
     const body = await res.json();
     expect(body[0].ga4PropertyId).toBe('properties/123456');
+    expect(body[0].ga4DisplayName).toBe('mysite.com - GA4');
+    expect(body[0].discoverySource).toBe('sc+ga4');
+  });
+
+  it('includes GA4-only properties as discovery candidates when the display name is an exact domain', async () => {
+    mockSc([]);
+    mockGa4([{ displayName: 'analytics-only.example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'analytics-only-example-com',
+      name: 'analytics-only.example.com',
+      domain: 'analytics-only.example.com',
+      searchConsole: false,
+      ga4PropertyId: 'properties/555',
+      ga4DisplayName: 'analytics-only.example.com',
+      discoverySource: 'ga4',
+    });
+  });
+
+  it('keeps a single SC-derived candidate when GA4 has the same exact-domain property name', async () => {
+    mockSc(['example.com']);
+    mockGa4([{ displayName: 'example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'example-com',
+      name: 'example.com',
+      domain: 'example.com',
+      searchConsole: true,
+      ga4PropertyId: 'properties/555',
+      ga4DisplayName: 'example.com',
+      discoverySource: 'sc+ga4',
+    });
+  });
+
+  it('keeps distinct candidates when different domains slugify to the same id', async () => {
+    mockSc(['a.b-c.com', 'a-b.c.com']);
+    mockGa4([]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'a-b-c-com',
+        domain: 'a.b-c.com',
+        searchConsole: true,
+      }),
+      expect.objectContaining({
+        id: 'a-b-c-com-2',
+        domain: 'a-b.c.com',
+        searchConsole: true,
+      }),
+    ]));
+  });
+
+  it('assigns a unique id when an SC-discovered candidate collides with an existing site id', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'analytics-only-example-com', name: 'Existing', domain: 'existing.com', testPages: [] },
+    ] as never);
+    mockSc(['analytics-only.example.com']);
+    mockGa4([]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'analytics-only-example-com-2',
+      domain: 'analytics-only.example.com',
+      searchConsole: true,
+      discoverySource: 'sc',
+    });
+  });
+
+  it('assigns a unique id when a GA4-only candidate collides with an existing site id', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'analytics-only-example-com', name: 'Existing', domain: 'existing.com', testPages: [] },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'analytics-only.example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'analytics-only-example-com-2',
+      domain: 'analytics-only.example.com',
+      searchConsole: false,
+      ga4PropertyId: 'properties/555',
+      discoverySource: 'ga4',
+    });
+  });
+
+  it('does not create GA4-only candidates from descriptive display names', async () => {
+    mockSc([]);
+    mockGa4([{ displayName: 'analytics-only.example.com GA4', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('excludes GA4-only properties when an existing site already owns the URL-prefix SC identity', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'existing', name: 'Existing', domain: 'other.example.com', scUrl: 'https://analytics-only.example.com/', testPages: [] },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'analytics-only.example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('excludes GA4-only properties when an existing site already owns the sc-domain identity', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'existing', name: 'Existing', domain: 'other.example.com', scUrl: 'sc-domain:analytics-only.example.com', testPages: [] },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'analytics-only.example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('does not fan out one GA4 property into multiple GA4-only site candidates', async () => {
+    mockSc([]);
+    mockGa4([{ displayName: 'alpha.example.com / beta.example.com', property: 'properties/555' }]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('does not create a GA4-only candidate when multiple exact-domain properties match the same domain', async () => {
+    mockSc([]);
+    mockGa4([
+      { displayName: 'analytics-only.example.com', property: 'properties/555' },
+      { displayName: 'analytics-only.example.com', property: 'properties/777' },
+    ]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
   });
 
   it('matches GA4 property when SC returns a URL-prefix property', async () => {
@@ -407,6 +567,43 @@ describe('GET /api/sites/discover', () => {
       ga4PropertyId: 'properties/111',
       isUpdate: true,
     });
+  });
+
+  it('does not auto-assign GA4 to an SC-discovered candidate when multiple exact-domain properties match', async () => {
+    mockSc(['mysite.com']);
+    mockGa4([
+      { displayName: 'mysite.com', property: 'properties/111' },
+      { displayName: 'mysite.com', property: 'properties/222' },
+    ]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'mysite-com',
+      domain: 'mysite.com',
+      searchConsole: true,
+      discoverySource: 'sc',
+    });
+    expect(body[0].ga4PropertyId).toBeUndefined();
+    expect(body[0].ga4DisplayName).toBeUndefined();
+  });
+
+  it('does not backfill an existing site when multiple exact-domain GA4 properties match', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: undefined },
+    ] as never);
+    mockSc([]);
+    mockGa4([
+      { displayName: 'mysite.com', property: 'properties/111' },
+      { displayName: 'mysite.com', property: 'properties/222' },
+    ]);
+
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
   });
 
   it('does not backfill existing site that already has a GA4 property ID', async () => {

--- a/src/lib/__tests__/api-sites.test.ts
+++ b/src/lib/__tests__/api-sites.test.ts
@@ -132,7 +132,7 @@ describe('POST /api/sites', () => {
     };
     vi.mocked(dbGetSites).mockReturnValue([existingSite] as never);
 
-    const res = await POST(postReq(updatedSite));
+    const res = await POST(postReq({ ...updatedSite, originalId: 'site1' }));
 
     expect(res.status).toBe(200);
     expect(dbUpsertSite).toHaveBeenCalledWith(updatedSite);
@@ -222,7 +222,7 @@ describe('POST /api/sites', () => {
     vi.mocked(dbGetSites).mockReturnValue([
       { id: 'site1', name: 'Site 1', domain: 'site1.com', testPages: [] },
     ] as never);
-    const res = await POST(postReq({ id: 'site1', name: 'Site 1 Updated', domain: 'site1.com' }));
+    const res = await POST(postReq({ id: 'site1', originalId: 'site1', name: 'Site 1 Updated', domain: 'site1.com' }));
     expect(res.status).toBe(200);
     expect(dbUpsertSite).toHaveBeenCalled();
   });
@@ -233,6 +233,46 @@ describe('POST /api/sites', () => {
     const data = await res.json();
     expect(data.ok).toBe(false);
     expect(data.errors.scUrl).toBeTruthy();
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when Search Console identity duplicates another site via scUrl', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'existing', name: 'Existing', domain: 'other.example.com', scUrl: 'https://blog.example.com/', testPages: [] },
+    ] as never);
+    const res = await POST(postReq({ id: 'site1', name: 'Site 1', domain: 'blog.example.com' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.scUrl).toMatch(/existing/);
+    expect(dbUpsertSite).not.toHaveBeenCalled();
+    expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
+  });
+
+  it('allows saving a site when the Search Console identity belongs to its own record', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'site1', name: 'Site 1', domain: 'other.example.com', scUrl: 'https://blog.example.com/', testPages: [] },
+    ] as never);
+    const res = await POST(postReq({ id: 'site1', originalId: 'site1', name: 'Site 1', domain: 'blog.example.com' }));
+    expect(res.status).toBe(200);
+    expect(dbUpsertSite).toHaveBeenCalledWith({
+      id: 'site1',
+      name: 'Site 1',
+      domain: 'blog.example.com',
+      testPages: [],
+    });
+  });
+
+  it('returns 400 when a new save reuses an existing site id', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'site1', name: 'Existing', domain: 'existing.com', testPages: [] },
+    ] as never);
+    const res = await POST(postReq({ id: 'site1', name: 'New Site', domain: 'newsite.com' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.errors.id).toMatch(/site1/);
     expect(dbUpsertSite).not.toHaveBeenCalled();
     expect(clearGa4DiscoveryCache).not.toHaveBeenCalled();
   });

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -63,6 +63,23 @@ describe('discoverPropertyIds', () => {
     expect(result[0].ga4PropertyId).toBe('12345');
   });
 
+  it('does not auto-assign GA4 when multiple exact-domain properties match the same site', async () => {
+    vi.mocked(getManagedSites).mockResolvedValue([
+      { id: 's1', name: 'Site1', domain: 'example.com', testPages: [] },
+    ] as never);
+    mockListAccountSummaries.mockResolvedValue([
+      [{
+        propertySummaries: [
+          { displayName: 'example.com', property: 'properties/12345' },
+          { displayName: 'example.com', property: 'properties/67890' },
+        ],
+      }],
+    ]);
+
+    const result = await discoverPropertyIds();
+    expect(result[0].ga4PropertyId).toBeUndefined();
+  });
+
   it('keeps existing ga4PropertyId if already set', async () => {
     vi.mocked(getManagedSites).mockResolvedValue([
       { id: 's1', name: 'Site1', domain: 'example.com', ga4PropertyId: '99999', testPages: [] },

--- a/src/lib/__tests__/sites.test.ts
+++ b/src/lib/__tests__/sites.test.ts
@@ -4,7 +4,15 @@ vi.mock('../db', () => ({ dbGetSites: vi.fn() }));
 
 import { dbGetSites } from '../db';
 import { isValidSiteId } from '../site-domain';
-import { getSCUrl, getManagedSite, getManagedSites, validateAndNormalizeSiteInput } from '../sites';
+import {
+  getSCUrl,
+  getManagedSite,
+  getManagedSites,
+  getSearchConsoleUrlIdentities,
+  getSiteSearchConsoleIdentities,
+  normalizeSearchConsoleIdentity,
+  validateAndNormalizeSiteInput,
+} from '../sites';
 import type { Site } from '../sites';
 
 function makeSite(overrides: Partial<Site> = {}): Site {
@@ -36,6 +44,30 @@ describe('getSCUrl', () => {
   it('uses URL-prefix scUrl for URL-prefix properties', () => {
     const site = makeSite({ scUrl: 'https://3h4x.github.io/', domain: '3h4x.github.io' });
     expect(getSCUrl(site)).toBe('https://3h4x.github.io/');
+  });
+});
+
+describe('Search Console identity helpers', () => {
+  it('normalizes identity strings for stable comparisons', () => {
+    expect(normalizeSearchConsoleIdentity(' HTTPS://Example.com/ ')).toBe('https://example.com');
+  });
+
+  it('expands URL-prefix identities to include the hostname', () => {
+    expect(getSearchConsoleUrlIdentities('https://blog.example.com/')).toEqual([
+      'https://blog.example.com',
+      'blog.example.com',
+    ]);
+  });
+
+  it('includes both hostname and SC override identities for a managed site', () => {
+    expect(getSiteSearchConsoleIdentities(makeSite({
+      domain: 'other.example.com',
+      scUrl: 'https://blog.example.com/',
+    }))).toEqual([
+      'other.example.com',
+      'https://blog.example.com',
+      'blog.example.com',
+    ]);
   });
 });
 
@@ -157,7 +189,7 @@ describe('validateAndNormalizeSiteInput', () => {
   it('allows update of a site with its own existing domain', () => {
     const existing = makeSite({ id: 'mysite', domain: 'mysite.com' });
     const result = validateAndNormalizeSiteInput(
-      { id: 'mysite', name: 'Updated', domain: 'mysite.com' },
+      { id: 'mysite', originalId: 'mysite', name: 'Updated', domain: 'mysite.com' },
       [existing],
     );
     expect(result.errors).toBeNull();
@@ -186,6 +218,50 @@ describe('validateAndNormalizeSiteInput', () => {
       [],
     );
     expect(result.errors?.ga4PropertyId).toBeTruthy();
+  });
+
+  it('returns field error when Search Console identity is already used by another site', () => {
+    const existing = makeSite({
+      id: 'existing',
+      domain: 'other.example.com',
+      scUrl: 'https://blog.example.com/',
+    });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'new-site', name: 'New Site', domain: 'blog.example.com' },
+      [existing],
+    );
+    expect(result.errors?.scUrl).toMatch(/existing/);
+  });
+
+  it('allows update when the Search Console identity belongs to the same site', () => {
+    const existing = makeSite({
+      id: 'existing',
+      domain: 'blog.example.com',
+      scUrl: 'https://blog.example.com/',
+    });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'existing', originalId: 'existing', name: 'Existing', domain: 'blog.example.com' },
+      [existing],
+    );
+    expect(result.errors).toBeNull();
+  });
+
+  it('returns field error when id is already used by another site and originalId is missing', () => {
+    const existing = makeSite({ id: 'existing', domain: 'existing.com' });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'existing', name: 'New Site', domain: 'newsite.com' },
+      [existing],
+    );
+    expect(result.errors?.id).toMatch(/existing/);
+  });
+
+  it('returns field error when originalId does not match the submitted id', () => {
+    const existing = makeSite({ id: 'existing', domain: 'existing.com' });
+    const result = validateAndNormalizeSiteInput(
+      { id: 'new-id', originalId: 'existing', name: 'Existing', domain: 'existing.com' },
+      [existing],
+    );
+    expect(result.errors?.id).toMatch(/changing site id/i);
   });
 
   it('accepts a valid ga4PropertyId', () => {

--- a/src/lib/ga4-discovery.ts
+++ b/src/lib/ga4-discovery.ts
@@ -1,3 +1,5 @@
+import { normalizeSiteDomain } from './site-domain';
+
 export const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
 export const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
 
@@ -11,17 +13,75 @@ interface SiteLike {
   ga4PropertyId?: string;
 }
 
+type PreparedGa4Property = DiscoveredGa4Property & {
+  exactDomain?: string;
+};
+
+function prepareGa4Properties(properties: DiscoveredGa4Property[]): PreparedGa4Property[] {
+  const prepared: PreparedGa4Property[] = [];
+
+  for (const property of properties) {
+    const displayName = property.displayName.trim();
+    const propertyId = property.propertyId.trim();
+    if (!displayName || !propertyId) continue;
+
+    prepared.push({
+      displayName,
+      propertyId,
+      exactDomain: normalizeSiteDomain(displayName) ?? undefined,
+    });
+  }
+
+  return prepared;
+}
+
+export function buildUniqueExactGa4Matches(properties: DiscoveredGa4Property[]): Map<string, DiscoveredGa4Property> {
+  const matches = new Map<string, DiscoveredGa4Property>();
+  const ambiguousDomains = new Set<string>();
+
+  for (const property of prepareGa4Properties(properties)) {
+    if (!property.exactDomain || ambiguousDomains.has(property.exactDomain)) continue;
+
+    const current = matches.get(property.exactDomain);
+    if (current) {
+      matches.delete(property.exactDomain);
+      ambiguousDomains.add(property.exactDomain);
+      continue;
+    }
+
+    matches.set(property.exactDomain, {
+      displayName: property.displayName,
+      propertyId: property.propertyId,
+    });
+  }
+
+  return matches;
+}
+
+export function findMatchingGa4Property(domain: string, properties: DiscoveredGa4Property[]): DiscoveredGa4Property | undefined {
+  const domainLower = domain.trim().toLowerCase();
+  if (!domainLower) return undefined;
+
+  const matches = prepareGa4Properties(properties).filter((property) => {
+    if (property.exactDomain === domainLower) return true;
+
+    const displayName = property.displayName.toLowerCase();
+    return displayName.includes(domainLower) || domainLower.includes(displayName);
+  });
+
+  if (matches.length !== 1) return undefined;
+
+  return {
+    displayName: matches[0].displayName,
+    propertyId: matches[0].propertyId,
+  };
+}
+
 export function resolveSiteGa4PropertyId(
   site: SiteLike,
   properties: DiscoveredGa4Property[],
 ): string | undefined {
   if (site.ga4PropertyId) return site.ga4PropertyId;
 
-  const domain = site.domain.toLowerCase();
-  const property = properties.find((candidate) => {
-    const displayName = candidate.displayName.toLowerCase();
-    return displayName.includes(domain) || domain.includes(displayName);
-  });
-
-  return property?.propertyId;
+  return findMatchingGa4Property(site.domain, properties)?.propertyId;
 }

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -25,11 +25,53 @@ export interface NormalizedSiteInput {
   site: Site;
 }
 
+type SiteIdentityInput = Pick<Site, 'domain' | 'scUrl'>;
+
 /** Returns the URL to use for Search Console API calls for a given site. */
-export function getSCUrl(site: Site): string {
+export function getSCUrl(site: SiteIdentityInput): string {
   const url = site.scUrl ?? site.domain;
   if (url.startsWith('sc-domain:') || url.startsWith('http')) return url;
   return `sc-domain:${url}`;
+}
+
+export function normalizeSearchConsoleIdentity(value: string): string {
+  return value.trim().toLowerCase().replace(/\/$/, '');
+}
+
+export function getSearchConsoleUrlIdentities(scUrl: string): string[] {
+  const normalizedScUrl = normalizeSearchConsoleIdentity(scUrl);
+  if (!normalizedScUrl) return [];
+
+  const identities = new Set<string>([normalizedScUrl]);
+
+  if (normalizedScUrl.startsWith('sc-domain:')) {
+    const domain = normalizeSiteDomain(normalizedScUrl.slice('sc-domain:'.length));
+    if (domain) identities.add(domain);
+    return [...identities];
+  }
+
+  if (/^https?:\/\//i.test(normalizedScUrl)) {
+    try {
+      const domain = normalizeSiteDomain(new URL(normalizedScUrl).hostname);
+      if (domain) identities.add(domain);
+    } catch {
+      // Validation happens elsewhere; identity expansion is best-effort.
+    }
+  }
+
+  return [...identities];
+}
+
+export function getSiteSearchConsoleIdentities(site: SiteIdentityInput): string[] {
+  const identities = new Set<string>();
+  const normalizedDomain = normalizeSiteDomain(site.domain);
+  if (normalizedDomain) identities.add(normalizedDomain);
+
+  for (const identity of getSearchConsoleUrlIdentities(getSCUrl(site))) {
+    identities.add(identity);
+  }
+
+  return [...identities];
 }
 
 import { dbGetSites } from './db';
@@ -46,10 +88,21 @@ export function validateAndNormalizeSiteInput(
   const errors: SiteFieldErrors = {};
 
   const id = typeof body.id === 'string' ? body.id.trim() : '';
+  const originalId = typeof body.originalId === 'string' ? body.originalId.trim() : '';
   if (!id) {
     errors.id = 'id is required';
   } else if (!isValidSiteId(id)) {
     errors.id = 'id must contain only letters, digits, hyphens, underscores, or dots and must not start with a special character';
+  }
+  if (originalId && !isValidSiteId(originalId)) {
+    errors.id = 'originalId must be a valid existing site id';
+  } else if (originalId && originalId !== id) {
+    errors.id = 'changing site id is not supported';
+  }
+
+  const existingById = existingSites.find(site => site.id === id);
+  if (existingById && originalId !== id) {
+    errors.id = `id is already used by site "${existingById.id}"`;
   }
 
   const name = typeof body.name === 'string' ? body.name.trim() : '';
@@ -85,6 +138,20 @@ export function validateAndNormalizeSiteInput(
   if (Object.keys(errors).length > 0) return { errors, normalized: null };
 
   const scUrl = getSiteScUrlOverride(rawDomain, rawScUrl || undefined);
+  const nextScIdentities = new Set(getSiteSearchConsoleIdentities({ domain: normalizedDomain!, scUrl }));
+  const scDuplicate = existingSites.find((site) => (
+    site.id !== id &&
+    getSiteSearchConsoleIdentities(site).some(identity => nextScIdentities.has(identity))
+  ));
+  if (scDuplicate) {
+    return {
+      errors: {
+        scUrl: `Search Console identity is already used by site "${scDuplicate.id}"`,
+      },
+      normalized: null,
+    };
+  }
+
   const site: Site = {
     ...(raw as Site),
     id,
@@ -101,6 +168,7 @@ export function validateAndNormalizeSiteInput(
   }
 
   delete (site as unknown as Record<string, unknown>).sortOrder;
+  delete (site as unknown as Record<string, unknown>).originalId;
 
   return { errors: null, normalized: { site } };
 }


### PR DESCRIPTION
Closes #42

Implemented via TamTam from issue [#42](https://github.com/3h4x/seo-tools/issues/42).