### PR TITLE
fix: Detect redirect chains during audit so crawl budget waste surfaces before Google penalizes it

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -9,7 +9,7 @@ import {
   cachedGetSearchConsoleQueries,
   cachedGetSitemapSubmissions,
 } from '@/lib/search-console';
-import { cachedAuditSite } from '@/lib/audit';
+import { cachedAuditSite, normalizeSiteAuditResult } from '@/lib/audit';
 import { analyzeSiteGaps } from '@/lib/gaps';
 import { summarizeCanonicalChecks } from '@/lib/canonical';
 import { getScDaily, getGa4Daily, getKeywordDeltas } from '@/lib/db';
@@ -84,7 +84,7 @@ export default async function SiteDashboardPage({
 
   const scUrl = getSCUrl(site);
 
-  const [audit, sitemapSubmissions, scComparison, scQueries, ga4Data, cwvSummary] = await Promise.all([
+  const [rawAudit, sitemapSubmissions, scComparison, scQueries, ga4Data, cwvSummary] = await Promise.all([
     cachedAuditSite(site),
     site.searchConsole ? cachedGetSitemapSubmissions(scUrl) : Promise.resolve([]),
     site.searchConsole ? cachedGetSearchConsoleDataWithComparison(scUrl, days) : null,
@@ -93,6 +93,7 @@ export default async function SiteDashboardPage({
     getCwvAuditSummary(siteId),
   ]);
 
+  const audit = normalizeSiteAuditResult(rawAudit);
   const gapAnalysis = analyzeSiteGaps(audit, site);
   const sections = gapsBySection(gapAnalysis.gaps);
   const totalGaps = gapAnalysis.gaps.length;
@@ -459,6 +460,37 @@ export default async function SiteDashboardPage({
               ))}
             </div>
             {sections['imageSeo']?.map(g => <Recommendation key={g.id} gap={g} />)}
+          </AuditPanel>
+          <AuditPanel title={`Redirect Chains · ${audit.redirectChains.length} pages checked`}>
+            <div className="space-y-3">
+              {audit.redirectChains.map((chain, i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="flex items-center gap-4 text-xs">
+                    <div className={`size-1.5 rounded-full shrink-0 ${statusDots[chain.status]}`} />
+                    <span className="text-neutral-400 font-mono w-32 shrink-0">{chain.page}</span>
+                    <span className="text-neutral-300 font-mono">{chain.message}</span>
+                  </div>
+                  <div className="ml-5 space-y-1">
+                    {chain.hops.length > 0 ? (
+                      <>
+                        {chain.hops.map((hop, j) => (
+                          <div key={j} className="text-[11px] font-mono text-neutral-500 break-all">
+                            {hop.url} <span className="text-neutral-400">HTTP {hop.status}</span>
+                            {hop.location ? ` -> ${hop.location}` : ''}
+                          </div>
+                        ))}
+                        {chain.finalUrl !== chain.hops[chain.hops.length - 1]?.url && (
+                          <div className="text-[11px] font-mono text-neutral-600 break-all">{chain.finalUrl}</div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="text-[11px] font-mono text-neutral-600 break-all">{chain.finalUrl}</div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {sections['redirectChains']?.map(g => <Recommendation key={g.id} gap={g} />)}
           </AuditPanel>
           <AuditPanel title={`Internal Links · ${audit.internalLinks.length} pages checked`}>
             <div className="space-y-3">

--- a/src/lib/__tests__/audit-async.test.ts
+++ b/src/lib/__tests__/audit-async.test.ts
@@ -299,6 +299,77 @@ describe('auditSite — security', () => {
   });
 });
 
+describe('auditSite — redirect chains', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSitemapsList.mockResolvedValue({ data: { sitemap: [] } });
+    mockSearchAnalyticsQuery.mockResolvedValue({ data: { rows: [] } });
+  });
+
+  it('fails a single-hop 303 redirect as non-permanent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { redirect?: string }) => {
+        const u = String(url);
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/source</loc></url></urlset>' });
+        }
+        if (u === 'http://example.com/' && opts?.redirect === 'manual') {
+          return Promise.resolve(new Response('', { status: 301, headers: { location: 'https://example.com/' } }));
+        }
+        if (u === 'https://example.com/source' && opts?.redirect === 'manual') {
+          return Promise.resolve(new Response('', { status: 303, headers: { location: 'https://example.com/target' } }));
+        }
+        if (u === 'https://example.com/target' && opts?.redirect === 'manual') {
+          return makeResponse({ body: '<html><title>Target</title></html>' });
+        }
+        return makeResponse({ body: '<html><title>Source</title></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite({ testPages: ['/source'] }));
+    const chain = result.redirectChains.find(c => c.page === '/source');
+    expect(chain?.status).toBe('fail');
+    expect(chain?.hasTemporaryRedirect).toBe(true);
+    expect(chain?.message).toContain('temporary redirect');
+    expect(result.score.fail).toBeGreaterThan(0);
+  });
+
+  it('passes single-hop 301 and 308 redirects as permanent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, opts?: { redirect?: string }) => {
+        const u = String(url);
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({
+            body: '<urlset><url><loc>https://example.com/permanent-301</loc></url><url><loc>https://example.com/permanent-308</loc></url></urlset>',
+          });
+        }
+        if (u === 'http://example.com/' && opts?.redirect === 'manual') {
+          return Promise.resolve(new Response('', { status: 301, headers: { location: 'https://example.com/' } }));
+        }
+        if (u === 'https://example.com/permanent-301' && opts?.redirect === 'manual') {
+          return Promise.resolve(new Response('', { status: 301, headers: { location: 'https://example.com/target-301' } }));
+        }
+        if (u === 'https://example.com/permanent-308' && opts?.redirect === 'manual') {
+          return Promise.resolve(new Response('', { status: 308, headers: { location: 'https://example.com/target-308' } }));
+        }
+        return makeResponse({ body: '<html><title>Permanent</title></html>' });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite({ testPages: ['/permanent-301', '/permanent-308'] }));
+    expect(result.redirectChains.find(c => c.page === '/permanent-301')?.status).toBe('pass');
+    expect(result.redirectChains.find(c => c.page === '/permanent-308')?.status).toBe('pass');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // skipChecks
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -34,6 +34,7 @@ function makeAudit(overrides: Partial<SiteAuditResult> = {}): SiteAuditResult {
     sitemap: { ...makeCheckResult('pass', 'Sitemap'), url: 'https://example.com/sitemap.xml', urlCount: 10, isIndex: false, hasLastmod: true, lastmodSample: new Date().toISOString().split('T')[0] },
     scSitemapFreshness: makeCheckResult('pass', 'SC Sitemap'),
     indexingCoverage: { ...makeCheckResult('pass', 'Indexing'), indexedPages: 10 },
+    redirectChains: [],
     metaTags: [makeMetaTagResult('/')],
     ogImage: makeCheckResult('pass', 'OG Image'),
     ttfb: { ...makeCheckResult('pass', 'TTFB'), ms: 300 },
@@ -108,6 +109,80 @@ describe('analyzeSiteGaps', () => {
     const gap = result.gaps.find(g => g.id === 'weak-meta-tags');
     expect(gap).toBeDefined();
     expect(gap?.affectedPages).toContain('/');
+  });
+
+  it('includes redirect-chains gap for unskipped redirect chain failures', () => {
+    const audit = makeAudit({
+      redirectChains: [{
+        ...makeCheckResult('fail', 'Redirect Chain'),
+        page: '/old-page',
+        requestedUrl: 'https://example.com/old-page',
+        finalUrl: 'https://example.com/new-page',
+        hops: [],
+        hopCount: 3,
+        hasTemporaryRedirect: false,
+        loopDetected: false,
+      }],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    const gap = result.gaps.find(g => g.id === 'redirect-chains');
+    expect(gap).toBeDefined();
+    expect(gap?.affectedPages).toContain('/old-page');
+  });
+
+  it('includes redirect-chains gap for two-hop permanent redirect warnings', () => {
+    const audit = makeAudit({
+      redirectChains: [{
+        ...makeCheckResult('warn', 'Redirect Chain'),
+        page: '/legacy',
+        requestedUrl: 'https://example.com/legacy',
+        finalUrl: 'https://example.com/current',
+        hops: [],
+        hopCount: 2,
+        hasTemporaryRedirect: false,
+        loopDetected: false,
+      }],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    const gap = result.gaps.find(g => g.id === 'redirect-chains');
+    expect(gap).toBeDefined();
+    expect(gap?.affectedPages).toContain('/legacy');
+  });
+
+  it('includes redirect-chains gap for single-hop temporary redirect failures', () => {
+    const audit = makeAudit({
+      redirectChains: [{
+        ...makeCheckResult('fail', 'Redirect Chain'),
+        page: '/temporary',
+        requestedUrl: 'https://example.com/temporary',
+        finalUrl: 'https://example.com/current',
+        hops: [{ url: 'https://example.com/temporary', status: 303, location: 'https://example.com/current' }],
+        hopCount: 1,
+        hasTemporaryRedirect: true,
+        loopDetected: false,
+      }],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    const gap = result.gaps.find(g => g.id === 'redirect-chains');
+    expect(gap).toBeDefined();
+    expect(gap?.affectedPages).toContain('/temporary');
+  });
+
+  it('does not include redirect-chains gap for skipped redirect chain checks', () => {
+    const audit = makeAudit({
+      redirectChains: [{
+        ...makeCheckResult('pass', 'Redirect Chain'),
+        page: '/old-page',
+        requestedUrl: 'https://example.com/old-page',
+        finalUrl: 'https://example.com/new-page',
+        hops: [],
+        hopCount: 3,
+        hasTemporaryRedirect: true,
+        loopDetected: true,
+      }],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    expect(result.gaps.find(g => g.id === 'redirect-chains')).toBeUndefined();
   });
 
   it('includes missing-og-image gap when og image fails', () => {

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -134,6 +134,10 @@ vi.mock('@/lib/search-console', () => ({
 
 vi.mock('@/lib/audit', () => ({
   cachedAuditSite: vi.fn(async () => makeAuditResult()),
+  normalizeSiteAuditResult: vi.fn((audit) => ({
+    ...audit,
+    redirectChains: audit.redirectChains ?? [],
+  })),
 }));
 
 vi.mock('@/lib/performance-site', () => ({
@@ -227,6 +231,7 @@ function makeAuditResult() {
       indexedPages: 8,
       coveragePct: 80,
     },
+    redirectChains: [],
     metaTags: [],
     ogImage: {
       ...makeCheckResult({ label: 'OG Image' }),

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -55,6 +55,22 @@ interface TtfbResult extends CheckResult {
   ms?: number;
 }
 
+interface RedirectHop {
+  url: string;
+  status: number;
+  location?: string;
+}
+
+interface RedirectChainResult extends CheckResult {
+  page: string;
+  requestedUrl: string;
+  finalUrl: string;
+  hops: RedirectHop[];
+  hopCount: number;
+  hasTemporaryRedirect: boolean;
+  loopDetected: boolean;
+}
+
 interface ImageDetail {
   src: string;
   hasAlt: boolean;
@@ -112,6 +128,7 @@ export interface SiteAuditResult {
   sitemap: SitemapResult;
   scSitemapFreshness: CheckResult;
   indexingCoverage: IndexingCoverageResult;
+  redirectChains: RedirectChainResult[];
   metaTags: MetaTagResult[];
   ogImage: OgImageResult;
   ttfb: TtfbResult;
@@ -120,6 +137,13 @@ export interface SiteAuditResult {
   security: SecurityResult;
   score: { pass: number; warn: number; fail: number; error: number; total: number };
   sampledPages: string[];
+}
+
+export function normalizeSiteAuditResult(audit: SiteAuditResult): SiteAuditResult {
+  return {
+    ...audit,
+    redirectChains: audit.redirectChains ?? [],
+  };
 }
 
 export const MAX_SAMPLED_PAGES = 10;
@@ -181,6 +205,8 @@ function getSc() {
 
 const FETCH_TIMEOUT = 30_000;
 const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const MAX_REDIRECT_HOPS = 10;
+const PERMANENT_REDIRECT_STATUSES = new Set([301, 308]);
 
 export interface FetchResult {
   ok: boolean;
@@ -612,6 +638,184 @@ async function checkTtfb(domain: string): Promise<TtfbResult> {
   return { status: 'fail', label: 'TTFB', message: `${ms}ms (very slow)`, ms };
 }
 
+function formatRedirectChainDetails(hops: RedirectHop[], finalUrl: string): string {
+  if (hops.length === 0) return finalUrl;
+
+  const parts = hops.map((hop) => `${hop.url} (${hop.status})`);
+  const lastLocation = hops[hops.length - 1]?.location;
+  if (lastLocation && lastLocation === finalUrl) {
+    parts.push(finalUrl);
+  }
+
+  return parts.join(' -> ');
+}
+
+function isPermanentRedirectStatus(status: number): boolean {
+  return PERMANENT_REDIRECT_STATUSES.has(status);
+}
+
+async function checkRedirectChain(pageUrl: string, page: string): Promise<RedirectChainResult> {
+  const seen = new Set<string>();
+  const hops: RedirectHop[] = [];
+  let currentUrl = pageUrl;
+  let finalUrl = pageUrl;
+  let hasTemporaryRedirect = false;
+
+  for (let depth = 0; depth < MAX_REDIRECT_HOPS; depth++) {
+    if (seen.has(currentUrl)) {
+      return {
+        status: 'fail',
+        label: 'Redirect Chain',
+        message: 'Redirect loop detected',
+        details: formatRedirectChainDetails(hops, finalUrl),
+        page,
+        requestedUrl: pageUrl,
+        finalUrl,
+        hops,
+        hopCount: hops.length,
+        hasTemporaryRedirect,
+        loopDetected: true,
+      };
+    }
+
+    seen.add(currentUrl);
+    const res = await safeFetch(currentUrl, { ua: GOOGLEBOT_UA, redirect: 'manual' });
+
+    if (res.status < 300 || res.status >= 400) {
+      finalUrl = currentUrl;
+
+      if (!res.ok) {
+        return {
+          status: 'error',
+          label: 'Redirect Chain',
+          message: res.error ? `Could not check: ${res.error}` : `Final response HTTP ${res.status}`,
+          details: formatRedirectChainDetails(hops, finalUrl),
+          page,
+          requestedUrl: pageUrl,
+          finalUrl,
+          hops,
+          hopCount: hops.length,
+          hasTemporaryRedirect,
+          loopDetected: false,
+        };
+      }
+
+      const hopCount = hops.length;
+      if (hopCount === 0) {
+        return {
+          status: 'pass',
+          label: 'Redirect Chain',
+          message: 'No redirects',
+          details: finalUrl,
+          page,
+          requestedUrl: pageUrl,
+          finalUrl,
+          hops,
+          hopCount,
+          hasTemporaryRedirect,
+          loopDetected: false,
+        };
+      }
+
+      if (hasTemporaryRedirect) {
+        return {
+          status: 'fail',
+          label: 'Redirect Chain',
+          message: `${hopCount} hop${hopCount === 1 ? '' : 's'} with temporary redirect`,
+          details: formatRedirectChainDetails(hops, finalUrl),
+          page,
+          requestedUrl: pageUrl,
+          finalUrl,
+          hops,
+          hopCount,
+          hasTemporaryRedirect,
+          loopDetected: false,
+        };
+      }
+
+      const status: CheckStatus = hopCount === 1 ? 'pass' : hopCount === 2 ? 'warn' : 'fail';
+      return {
+        status,
+        label: 'Redirect Chain',
+        message:
+          hopCount === 1
+            ? '1 permanent redirect hop'
+            : `${hopCount} redirect hops`,
+        details: formatRedirectChainDetails(hops, finalUrl),
+        page,
+        requestedUrl: pageUrl,
+        finalUrl,
+        hops,
+        hopCount,
+        hasTemporaryRedirect,
+        loopDetected: false,
+      };
+    }
+
+    const location = res.headers.get('location');
+    if (!location) {
+      return {
+        status: 'fail',
+        label: 'Redirect Chain',
+        message: `Redirect missing Location header (${res.status})`,
+        details: formatRedirectChainDetails(hops, finalUrl),
+        page,
+        requestedUrl: pageUrl,
+        finalUrl,
+        hops,
+        hopCount: hops.length,
+        hasTemporaryRedirect,
+        loopDetected: false,
+      };
+    }
+
+    let nextUrl: string;
+    try {
+      nextUrl = new URL(location, currentUrl).toString();
+    } catch {
+      return {
+        status: 'fail',
+        label: 'Redirect Chain',
+        message: `Invalid redirect target (${res.status})`,
+        details: location,
+        page,
+        requestedUrl: pageUrl,
+        finalUrl,
+        hops,
+        hopCount: hops.length,
+        hasTemporaryRedirect,
+        loopDetected: false,
+      };
+    }
+
+    if (!isPermanentRedirectStatus(res.status)) {
+      hasTemporaryRedirect = true;
+    }
+
+    hops.push({
+      url: currentUrl,
+      status: res.status,
+      location: nextUrl,
+    });
+    finalUrl = nextUrl;
+    currentUrl = nextUrl;
+  }
+
+  return {
+    status: 'fail',
+    label: 'Redirect Chain',
+    message: `Exceeded ${MAX_REDIRECT_HOPS} redirect hops`,
+    details: formatRedirectChainDetails(hops, finalUrl),
+    page,
+    requestedUrl: pageUrl,
+    finalUrl,
+    hops,
+    hopCount: hops.length,
+    hasTemporaryRedirect,
+    loopDetected: false,
+  };
+}
+
 async function checkSecurity(domain: string): Promise<SecurityResult> {
   // HTTPS: fetch http:// and check if it redirects to https://
   let httpsCheck: CheckResult;
@@ -813,24 +1017,28 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   const indexingCoverage = await checkIndexingCoverage(site, sitemap.urlCount);
 
   // Fetch sampled pages sequentially to avoid rate-limiting
-  const pageResults: { meta: MetaTagResult; images: ImageSeoResult; links: InternalLinkResult }[] = [];
+  const pageResults: { redirectChain: RedirectChainResult; meta: MetaTagResult; images: ImageSeoResult; links: InternalLinkResult }[] = [];
   for (const page of sampledPages) {
-    const res = await safeFetch(`https://${site.domain}${page}`, { ua: GOOGLEBOT_UA });
+    const pageUrl = `https://${site.domain}${page}`;
+    const redirectChain = await checkRedirectChain(pageUrl, page);
+    const res = await safeFetch(pageUrl, { ua: GOOGLEBOT_UA });
     const meta = parseMetaTags(res, page);
     if (res.ok) {
-      const canonicalCheck = await checkCanonicalUrl(`https://${site.domain}${page}`, meta.canonicalTarget);
+      const canonicalCheck = await checkCanonicalUrl(pageUrl, meta.canonicalTarget);
       meta.canonical = canonicalCheck.check;
       meta.canonicalValid = canonicalCheck.canonicalValid;
       meta.canonicalStatus = canonicalCheck.canonicalStatus;
       meta.canonicalTarget = canonicalCheck.canonicalTarget;
     }
     pageResults.push({
+      redirectChain,
       meta,
       images: res.ok ? checkImageSeo(res.text, page) : { page, totalImages: 0, withAlt: 0, withoutAlt: 0, withLazyLoading: 0, status: 'error' as CheckStatus, label: 'Images', message: res.error || `HTTP ${res.status}`, images: [] },
       links: res.ok ? checkInternalLinks(res.text, site.domain, page) : { page, internalLinks: 0, externalLinks: 0, status: 'error' as CheckStatus, label: 'Internal Links', message: res.error || `HTTP ${res.status}` },
     });
   }
 
+  const redirectChains = pageResults.map(r => r.redirectChain);
   const metaTags = pageResults.map(r => r.meta);
   const imageSeo = pageResults.map(r => r.images);
   const internalLinks = pageResults.map(r => r.links);
@@ -844,6 +1052,7 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   const skippedSitemap = applySkipToCheck(sitemap, skip, 'sitemap');
   const skippedScSitemapFreshness = applySkipToCheck(scSitemapFreshness, skip, 'scSitemap');
   const skippedIndexingCoverage = applySkipToCheck(indexingCoverage, skip, 'indexing');
+  const skippedRedirectChains = redirectChains.map(chain => applySkipToCheck(chain, skip, 'redirectChain'));
   const skippedOgImage = applySkipToCheck(ogImage, skip, 'ogImage');
   const skippedTtfb = applySkipToCheck(ttfb, skip, 'ttfb');
   const skippedSecurity = {
@@ -870,6 +1079,7 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     skippedSitemap,
     skippedScSitemapFreshness,
     skippedIndexingCoverage,
+    ...skippedRedirectChains,
     skippedOgImage,
     skippedTtfb,
     skippedSecurity.https,
@@ -893,6 +1103,7 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     sitemap: skippedSitemap,
     scSitemapFreshness: skippedScSitemapFreshness,
     indexingCoverage: skippedIndexingCoverage,
+    redirectChains: skippedRedirectChains,
     metaTags: skippedMetaTags,
     ogImage: skippedOgImage,
     ttfb: skippedTtfb,
@@ -914,7 +1125,8 @@ async function auditAllSites(): Promise<SiteAuditResult[]> {
 import { withCache, CACHE_TTL_WEEK } from './db';
 
 export async function cachedAuditSite(site: Site): Promise<SiteAuditResult> {
-  return (await withCache<SiteAuditResult>('audit', site.id, () => auditSite(site), CACHE_TTL_WEEK))!;
+  const audit = (await withCache<SiteAuditResult>('audit', site.id, () => auditSite(site), CACHE_TTL_WEEK))!;
+  return normalizeSiteAuditResult(audit);
 }
 
 export async function cachedAuditAllSites(): Promise<SiteAuditResult[]> {

--- a/src/lib/gaps.ts
+++ b/src/lib/gaps.ts
@@ -95,6 +95,21 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site): SiteGapAnal
     });
   }
 
+  const redirectChainIssues = (audit.redirectChains ?? []).filter(
+    (chain) => chain.status !== 'pass' && (chain.hopCount > 1 || chain.hasTemporaryRedirect || chain.loopDetected),
+  );
+  if (redirectChainIssues.length > 0) {
+    gaps.push({
+      id: 'redirect-chains',
+      title: 'Flatten redirect chains to single permanent redirects',
+      description: 'Some audited pages waste crawl budget with multi-hop or temporary redirects. Long chains slow down crawlers and temporary hops dilute canonical link equity.',
+      severity: 'medium',
+      category: 'crawlability',
+      hint: 'Update redirects so each legacy URL resolves in a single permanent 301 or 308 hop to the final canonical destination. Replace 302/303/307 redirects with 301 or 308 when the move is intended to be permanent.',
+      affectedPages: redirectChainIssues.map((chain) => chain.page),
+    });
+  }
+
   // MEDIUM: OG image missing
   if (audit.ogImage.status === 'fail') {
     gaps.push({
@@ -291,6 +306,7 @@ const GAP_SECTION_MAP: Record<string, string> = {
   'robots-no-sitemap-directive': 'robotsTxt',
   'missing-sitemap': 'sitemap',
   'stale-sitemap': 'sitemap',
+  'redirect-chains': 'redirectChains',
   'weak-meta-tags': 'metaTags',
   'missing-canonical': 'metaTags',
   'broken-canonical-targets': 'metaTags',

--- a/src/lib/skip-checks.ts
+++ b/src/lib/skip-checks.ts
@@ -3,6 +3,7 @@ export type SkipCheckId =
   | 'sitemap'
   | 'scSitemap'
   | 'indexing'
+  | 'redirectChain'
   | 'title'
   | 'description'
   | 'ogTitle'
@@ -30,6 +31,7 @@ export const SKIP_CHECK_OPTIONS: SkipCheckOption[] = [
   { id: 'sitemap', label: 'Sitemap' },
   { id: 'scSitemap', label: 'SC Sitemap' },
   { id: 'indexing', label: 'Indexing' },
+  { id: 'redirectChain', label: 'Redirect Chain', aliases: ['redirect-chain'] },
   { id: 'title', label: 'title' },
   { id: 'description', label: 'description' },
   { id: 'ogTitle', label: 'og:title' },


### PR DESCRIPTION
Closes #31

Picked ready issue `#31`, created the TamTam issue branch, implemented redirect-chain audit support and UI, and updated persistent memory.

---
Implemented via TamTam from issue [#31](https://github.com/3h4x/seo-tools/issues/31).