### PR TITLE
fix: Surface cross-site linking opportunities so co-owned properties share authority without external tools

### DIFF
--- a/app/audit/cross-links/page.tsx
+++ b/app/audit/cross-links/page.tsx
@@ -1,0 +1,157 @@
+import Link from 'next/link';
+import { DataTable, type DataTableColumn } from '../../components/data-table';
+import { getCrossLinkMatrix, type CrossLinkSourceMatrix, type CrossLinkSourceStatus } from '@/lib/cross-links';
+import { getManagedSites } from '@/lib/sites';
+
+export const revalidate = 300;
+
+const BASE_COLUMNS: DataTableColumn[] = [
+  { label: 'Source Site', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-neutral-300 text-xs' },
+  { label: 'Pages Crawled', align: 'right', className: 'px-4 py-3 font-semibold', cellClassName: 'px-4 py-2.5 text-right text-neutral-400' },
+];
+
+export default async function CrossLinksPage() {
+  const sites = await getManagedSites();
+  const matrix = await getCrossLinkMatrix(sites);
+  const evaluatedTargets = matrix
+    .filter((row) => row.status === 'ok')
+    .flatMap((row) => row.targets);
+  const totalLinkedCells = evaluatedTargets.filter((target) => (target.linkedPages ?? 0) > 0).length;
+  const zeroLinkCells = evaluatedTargets.filter((target) => target.linkedPages === 0).length;
+  const unavailableSources = matrix.filter((row) => row.status !== 'ok').length;
+
+  if (sites.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Cross-Site Links</h1>
+          <p className="text-neutral-500 text-sm mt-1">Managed-domain link coverage</p>
+        </div>
+        <p className="text-neutral-500 text-sm">
+          No sites configured — <Link href="/config" className="text-white underline">add sites in the Config tab</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  const targetColumns = sites.map((site) => ({
+    label: site.name,
+    align: 'right' as const,
+    className: 'px-4 py-3 font-semibold',
+    cellClassName: 'px-4 py-2.5 text-right',
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-white">Cross-Site Links</h1>
+            <Link href="/audit" className="text-sm text-neutral-500 hover:text-neutral-300 transition-colors">Back to audit</Link>
+          </div>
+          <p className="text-neutral-500 text-sm mt-1">Top Search Console pages crawled with Googlebot UA · cached 24h · unavailable sources show as N/A</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+        <SummaryCard label="Source Sites" value={matrix.length} accent="border-l-blue-500" valueClassName="text-blue-400" />
+        <SummaryCard label="Cells With Links" value={totalLinkedCells} accent="border-l-emerald-500" valueClassName="text-emerald-400" />
+        <SummaryCard label="Zero-Link Gaps" value={zeroLinkCells} accent="border-l-red-500" valueClassName="text-red-400" />
+        <SummaryCard label="Unavailable Sources" value={unavailableSources} accent="border-l-neutral-600" valueClassName="text-neutral-300" />
+      </div>
+
+      <DataTable
+        columns={[...BASE_COLUMNS, ...targetColumns]}
+        rows={matrix.map((row) => [
+          <div key="source" className="space-y-0.5">
+            <div className="text-white font-semibold">{row.sourceSiteName}</div>
+            <div className="text-neutral-500 text-[10px]">{row.sourceDomain}</div>
+          </div>,
+          <SourcePagesCell key="pages" row={row} />,
+          ...sites.map((site) => {
+            if (site.id === row.sourceSiteId) {
+              return <span key={site.id} className="text-neutral-700">—</span>;
+            }
+
+            const target = row.targets.find((entry) => entry.targetSiteId === site.id);
+            if (!target) {
+              return <span key={site.id} className="text-neutral-700">—</span>;
+            }
+
+            return (
+              <div key={site.id} className="space-y-0.5">
+                {row.status !== 'ok' || target.linkedPages === null || target.missingPages === null ? (
+                  <>
+                    <div className="text-neutral-500 font-semibold">{sourceStatusLabel(row.status)}</div>
+                    <div className="text-neutral-700 text-[10px]">Not evaluated</div>
+                  </>
+                ) : (
+                  <>
+                    <div className={target.linkedPages === 0 ? 'text-red-400 font-semibold' : 'text-emerald-400 font-semibold'}>
+                      {target.linkedPages === 0 ? '0 links' : `${target.linkedPages} link${target.linkedPages === 1 ? '' : 's'}`}
+                    </div>
+                    <div className="text-neutral-600 text-[10px]">{target.missingPages} pages missing</div>
+                  </>
+                )}
+              </div>
+            );
+          }),
+        ])}
+        rowKeys={matrix.map((row) => row.sourceSiteId)}
+        monospaceCells={false}
+        containerClassName="bg-neutral-900 rounded-lg border border-neutral-800 overflow-x-auto"
+        tableClassName="w-full min-w-[840px] text-sm"
+        headRowClassName="border-b border-neutral-800 text-neutral-500 text-xs uppercase tracking-wider"
+        rowClassName="hover:bg-neutral-800/30 transition-colors align-top"
+      />
+    </div>
+  );
+}
+
+function SummaryCard(
+  { label, value, accent, valueClassName }: { label: string; value: number; accent: string; valueClassName: string },
+) {
+  return (
+    <div className={`bg-neutral-900 rounded-lg border border-neutral-800 border-l-4 ${accent} p-4`}>
+      <div className="text-neutral-500 text-xs uppercase tracking-wider">{label}</div>
+      <div className={`text-2xl font-bold font-mono mt-2 ${valueClassName}`}>{value}</div>
+    </div>
+  );
+}
+
+function SourcePagesCell({ row }: { row: CrossLinkSourceMatrix }) {
+  if (row.status !== 'ok') {
+    return (
+      <div className="space-y-0.5">
+        <div className="text-neutral-400 font-medium">{sourceStatusLabel(row.status)}</div>
+        <div className="text-neutral-700 text-[10px]">Not evaluated</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      <div>{row.crawledPages}</div>
+      {row.failedPages > 0 && (
+        <div className="text-amber-400 text-[10px]">
+          {row.failedPages} fetch {row.failedPages === 1 ? 'failed' : 'failures'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function sourceStatusLabel(status: CrossLinkSourceStatus): string {
+  switch (status) {
+    case 'disabled':
+      return 'SC disabled';
+    case 'search-console-unavailable':
+      return 'SC unavailable';
+    case 'crawl-unavailable':
+      return 'Crawl failed';
+    case 'no-pages':
+      return 'No pages';
+    case 'ok':
+      return 'OK';
+  }
+}

--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -137,6 +137,11 @@ export default async function AuditPage({ searchParams }: { searchParams: Promis
       <div>
         <h1 className="text-2xl font-bold text-white">SEO Audit</h1>
         <p className="text-neutral-500 text-sm mt-1">Live checks · {audits.length} sites</p>
+        <div className="mt-3">
+          <Link href="/audit/cross-links" className="inline-flex items-center rounded-full border border-neutral-800 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800/50 transition-colors">
+            Cross-site links
+          </Link>
+        </div>
       </div>
       <div className="flex gap-6 items-center">
         <div className="bg-neutral-900 rounded-lg border border-neutral-800 p-5 flex items-center gap-5 shrink-0">

--- a/src/lib/__tests__/cross-links-page.test.tsx
+++ b/src/lib/__tests__/cross-links-page.test.tsx
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactNode } from 'react';
+import type { CrossLinkSourceMatrix } from '../cross-links';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const {
+  mockGetManagedSites,
+  mockGetCrossLinkMatrix,
+} = vi.hoisted(() => ({
+  mockGetManagedSites: vi.fn(),
+  mockGetCrossLinkMatrix: vi.fn(),
+}));
+
+vi.mock('@/lib/sites', () => ({
+  getManagedSites: mockGetManagedSites,
+}));
+
+vi.mock('@/lib/cross-links', () => ({
+  getCrossLinkMatrix: mockGetCrossLinkMatrix,
+}));
+
+vi.mock('../../../app/components/data-table', () => ({
+  DataTable: ({ rows }: { rows: ReactNode[][] }) => (
+    <div>
+      {rows.map((row, rowIndex) => (
+        <div key={rowIndex}>
+          {row.map((cell, cellIndex) => (
+            <div key={cellIndex}>{cell}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import CrossLinksPage from '../../../app/audit/cross-links/page';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CrossLinksPage', () => {
+  it('renders unavailable sources as N/A and excludes them from zero-link gap totals', async () => {
+    mockGetManagedSites.mockResolvedValue([
+      { id: 'alpha', name: 'Alpha', domain: 'alpha.test', testPages: ['/'] },
+      { id: 'beta', name: 'Beta', domain: 'beta.test', testPages: ['/'] },
+    ]);
+
+    const matrix: CrossLinkSourceMatrix[] = [
+      {
+        sourceSiteId: 'alpha',
+        sourceSiteName: 'Alpha',
+        sourceDomain: 'alpha.test',
+        status: 'ok',
+        attemptedPages: 2,
+        crawledPages: 1,
+        failedPages: 1,
+        targets: [
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'beta',
+        sourceSiteName: 'Beta',
+        sourceDomain: 'beta.test',
+        status: 'search-console-unavailable',
+        attemptedPages: 0,
+        crawledPages: 0,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+        ],
+      },
+    ];
+
+    mockGetCrossLinkMatrix.mockResolvedValue(matrix);
+
+    const page = await CrossLinksPage();
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain('Zero-Link Gaps');
+    expect(html).toContain('>1<');
+    expect(html).toContain('Unavailable Sources');
+    expect(html).toContain('SC unavailable');
+    expect(html).toContain('Not evaluated');
+    expect(html).toContain('1 fetch failed');
+  });
+});

--- a/src/lib/__tests__/cross-links.test.ts
+++ b/src/lib/__tests__/cross-links.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getCrossLinkMatrix } from '../cross-links';
+import type { Site } from '../sites';
+
+const {
+  mockCachedGetSearchConsolePages,
+  mockWithCache,
+} = vi.hoisted(() => ({
+  mockCachedGetSearchConsolePages: vi.fn(),
+  mockWithCache: vi.fn(async (
+    _key: string,
+    _id: string,
+    fetcher: () => Promise<unknown>,
+    _ttlMs?: number,
+  ) => fetcher()),
+}));
+
+vi.mock('../search-console', () => ({
+  cachedGetSearchConsolePages: mockCachedGetSearchConsolePages,
+}));
+
+vi.mock('../db', () => ({
+  withCache: mockWithCache,
+}));
+
+const sites: Site[] = [
+  { id: 'alpha', name: 'Alpha', domain: 'alpha.test', testPages: ['/'] },
+  { id: 'beta', name: 'Beta', domain: 'beta.test', testPages: ['/'] },
+  { id: 'gamma', name: 'Gamma', domain: 'gamma.test', testPages: ['/'] },
+];
+
+const overlappingSites: Site[] = [
+  { id: 'apex', name: 'Apex', domain: 'example.com', testPages: ['/'] },
+  { id: 'blog', name: 'Blog', domain: 'blog.example.com', testPages: ['/'] },
+  { id: 'partner', name: 'Partner', domain: 'partner.test', testPages: ['/'] },
+];
+
+describe('getCrossLinkMatrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === 'https://alpha.test/post-a') {
+        return new Response('<a href="https://beta.test/docs">Beta</a><a href="/self">Self</a>');
+      }
+      if (url === 'https://alpha.test/post-b') {
+        return new Response('<a href="https://news.gamma.test/story">Gamma</a>');
+      }
+      if (url === 'https://beta.test/home') {
+        return new Response('<a href="https://alpha.test/start">Alpha</a>');
+      }
+      if (url === 'https://gamma.test/about') {
+        return new Response('<a href="mailto:test@gamma.test">Mail</a>');
+      }
+      return new Response('', { status: 404 });
+    }) as typeof fetch);
+
+    mockCachedGetSearchConsolePages.mockImplementation((siteUrl: string) => {
+      if (siteUrl === 'sc-domain:alpha.test') {
+        return [{ page: '/post-a' }, { page: 'https://alpha.test/post-b' }];
+      }
+      if (siteUrl === 'sc-domain:beta.test') {
+        return [{ page: '/home' }];
+      }
+      if (siteUrl === 'sc-domain:gamma.test') {
+        return [{ page: '/about' }];
+      }
+      return [];
+    });
+  });
+
+  it('builds per-site outbound counts to other managed domains and caches each source row', async () => {
+    const matrix = await getCrossLinkMatrix(sites);
+
+    expect(mockWithCache).toHaveBeenCalledTimes(3);
+    for (const call of mockWithCache.mock.calls) {
+      expect(call[0]).toBe('cross-links-matrix');
+      expect(call[3]).toBe(24 * 60 * 60 * 1000);
+    }
+
+    expect(matrix).toEqual([
+      {
+        sourceSiteId: 'alpha',
+        sourceSiteName: 'Alpha',
+        sourceDomain: 'alpha.test',
+        status: 'ok',
+        attemptedPages: 2,
+        crawledPages: 2,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: 1,
+            missingPages: 1,
+            linkedExamples: ['https://alpha.test/post-a'],
+          },
+          {
+            targetSiteId: 'gamma',
+            targetSiteName: 'Gamma',
+            targetDomain: 'gamma.test',
+            linkedPages: 1,
+            missingPages: 1,
+            linkedExamples: ['https://alpha.test/post-b'],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'beta',
+        sourceSiteName: 'Beta',
+        sourceDomain: 'beta.test',
+        status: 'ok',
+        attemptedPages: 1,
+        crawledPages: 1,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: 1,
+            missingPages: 0,
+            linkedExamples: ['https://beta.test/home'],
+          },
+          {
+            targetSiteId: 'gamma',
+            targetSiteName: 'Gamma',
+            targetDomain: 'gamma.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'gamma',
+        sourceSiteName: 'Gamma',
+        sourceDomain: 'gamma.test',
+        status: 'ok',
+        attemptedPages: 1,
+        crawledPages: 1,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('marks disabled and Search Console-unavailable sources as not evaluated', async () => {
+    const mixedSites: Site[] = [
+      { id: 'alpha', name: 'Alpha', domain: 'alpha.test', testPages: ['/'], searchConsole: false },
+      { id: 'beta', name: 'Beta', domain: 'beta.test', testPages: ['/'] },
+    ];
+
+    mockCachedGetSearchConsolePages.mockImplementation((siteUrl: string) => {
+      if (siteUrl === 'sc-domain:beta.test') {
+        return null;
+      }
+      return [];
+    });
+
+    const matrix = await getCrossLinkMatrix(mixedSites);
+
+    expect(matrix).toEqual([
+      {
+        sourceSiteId: 'alpha',
+        sourceSiteName: 'Alpha',
+        sourceDomain: 'alpha.test',
+        status: 'disabled',
+        attemptedPages: 0,
+        crawledPages: 0,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'beta',
+        sourceSiteName: 'Beta',
+        sourceDomain: 'beta.test',
+        status: 'search-console-unavailable',
+        attemptedPages: 0,
+        crawledPages: 0,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('excludes failed page fetches from missing-page counts and marks fully failed crawls unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === 'https://alpha.test/post-a') {
+        return new Response('<a href="https://beta.test/docs">Beta</a>');
+      }
+      if (url === 'https://alpha.test/post-b') {
+        throw new Error('timeout');
+      }
+      if (url === 'https://beta.test/home') {
+        return new Response('', { status: 503 });
+      }
+      return new Response('', { status: 404 });
+    }) as typeof fetch);
+
+    mockCachedGetSearchConsolePages.mockImplementation((siteUrl: string) => {
+      if (siteUrl === 'sc-domain:alpha.test') {
+        return [{ page: '/post-a' }, { page: '/post-b' }];
+      }
+      if (siteUrl === 'sc-domain:beta.test') {
+        return [{ page: '/home' }];
+      }
+      if (siteUrl === 'sc-domain:gamma.test') {
+        return [];
+      }
+      return [];
+    });
+
+    const matrix = await getCrossLinkMatrix(sites);
+
+    expect(matrix).toEqual([
+      {
+        sourceSiteId: 'alpha',
+        sourceSiteName: 'Alpha',
+        sourceDomain: 'alpha.test',
+        status: 'ok',
+        attemptedPages: 2,
+        crawledPages: 1,
+        failedPages: 1,
+        targets: [
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: 1,
+            missingPages: 0,
+            linkedExamples: ['https://alpha.test/post-a'],
+          },
+          {
+            targetSiteId: 'gamma',
+            targetSiteName: 'Gamma',
+            targetDomain: 'gamma.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'beta',
+        sourceSiteName: 'Beta',
+        sourceDomain: 'beta.test',
+        status: 'crawl-unavailable',
+        attemptedPages: 1,
+        crawledPages: 0,
+        failedPages: 1,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+          {
+            targetSiteId: 'gamma',
+            targetSiteName: 'Gamma',
+            targetDomain: 'gamma.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'gamma',
+        sourceSiteName: 'Gamma',
+        sourceDomain: 'gamma.test',
+        status: 'no-pages',
+        attemptedPages: 0,
+        crawledPages: 0,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'alpha',
+            targetSiteName: 'Alpha',
+            targetDomain: 'alpha.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+          {
+            targetSiteId: 'beta',
+            targetSiteName: 'Beta',
+            targetDomain: 'beta.test',
+            linkedPages: null,
+            missingPages: null,
+            linkedExamples: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('prefers the most specific managed domain when apex and subdomain sites overlap', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === 'https://example.com/home') {
+        return new Response('<a href="https://blog.example.com/post-1">Blog</a>');
+      }
+      if (url === 'https://blog.example.com/post-1') {
+        return new Response('<a href="https://example.com/docs">Apex</a>');
+      }
+      if (url === 'https://partner.test/start') {
+        return new Response('<a href="https://news.blog.example.com/story">Blog network</a>');
+      }
+      return new Response('', { status: 404 });
+    }) as typeof fetch);
+
+    mockCachedGetSearchConsolePages.mockImplementation((siteUrl: string) => {
+      if (siteUrl === 'sc-domain:example.com') {
+        return [{ page: '/home' }];
+      }
+      if (siteUrl === 'sc-domain:blog.example.com') {
+        return [{ page: '/post-1' }];
+      }
+      if (siteUrl === 'sc-domain:partner.test') {
+        return [{ page: '/start' }];
+      }
+      return [];
+    });
+
+    const matrix = await getCrossLinkMatrix(overlappingSites);
+
+    expect(matrix).toEqual([
+      {
+        sourceSiteId: 'apex',
+        sourceSiteName: 'Apex',
+        sourceDomain: 'example.com',
+        status: 'ok',
+        attemptedPages: 1,
+        crawledPages: 1,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'blog',
+            targetSiteName: 'Blog',
+            targetDomain: 'blog.example.com',
+            linkedPages: 1,
+            missingPages: 0,
+            linkedExamples: ['https://example.com/home'],
+          },
+          {
+            targetSiteId: 'partner',
+            targetSiteName: 'Partner',
+            targetDomain: 'partner.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'blog',
+        sourceSiteName: 'Blog',
+        sourceDomain: 'blog.example.com',
+        status: 'ok',
+        attemptedPages: 1,
+        crawledPages: 1,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'apex',
+            targetSiteName: 'Apex',
+            targetDomain: 'example.com',
+            linkedPages: 1,
+            missingPages: 0,
+            linkedExamples: ['https://blog.example.com/post-1'],
+          },
+          {
+            targetSiteId: 'partner',
+            targetSiteName: 'Partner',
+            targetDomain: 'partner.test',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+        ],
+      },
+      {
+        sourceSiteId: 'partner',
+        sourceSiteName: 'Partner',
+        sourceDomain: 'partner.test',
+        status: 'ok',
+        attemptedPages: 1,
+        crawledPages: 1,
+        failedPages: 0,
+        targets: [
+          {
+            targetSiteId: 'apex',
+            targetSiteName: 'Apex',
+            targetDomain: 'example.com',
+            linkedPages: 0,
+            missingPages: 1,
+            linkedExamples: [],
+          },
+          {
+            targetSiteId: 'blog',
+            targetSiteName: 'Blog',
+            targetDomain: 'blog.example.com',
+            linkedPages: 1,
+            missingPages: 0,
+            linkedExamples: ['https://partner.test/start'],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../db', () => ({
+  clearCache: vi.fn(),
   clearCacheEntry: vi.fn(),
   clearCacheEntriesByPrefix: vi.fn(),
   clearSitemapSyncState: vi.fn(),
 }));
 
-import { clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from '../db';
+import { clearCache, clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from '../db';
 import { invalidateManagedSiteCache } from '../site-cache';
 import type { Site } from '../sites';
 
@@ -30,6 +31,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(null, site);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
     expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
@@ -55,6 +57,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(previous, next);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:old.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
@@ -76,6 +79,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(previous, next);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
   });
 
@@ -85,6 +89,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(previous, next);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearSitemapSyncState).not.toHaveBeenCalled();
   });
 
@@ -93,6 +98,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(previous, null);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
   });
 
@@ -102,6 +108,7 @@ describe('invalidateManagedSiteCache', () => {
 
     invalidateManagedSiteCache(previous, next);
 
+    expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
     expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');

--- a/src/lib/cross-links.ts
+++ b/src/lib/cross-links.ts
@@ -1,0 +1,253 @@
+import { withCache } from './db';
+import { cachedGetSearchConsolePages } from './search-console';
+import { normalizeSiteDomain } from './site-domain';
+import { getSCUrl, type Site } from './sites';
+
+const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const FETCH_TIMEOUT_MS = 30_000;
+const CROSS_LINK_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CrossLinkTarget {
+  targetSiteId: string;
+  targetSiteName: string;
+  targetDomain: string;
+  linkedPages: number | null;
+  missingPages: number | null;
+  linkedExamples: string[];
+}
+
+export type CrossLinkSourceStatus =
+  | 'ok'
+  | 'disabled'
+  | 'search-console-unavailable'
+  | 'crawl-unavailable'
+  | 'no-pages';
+
+export interface CrossLinkSourceMatrix {
+  sourceSiteId: string;
+  sourceSiteName: string;
+  sourceDomain: string;
+  status: CrossLinkSourceStatus;
+  attemptedPages: number;
+  crawledPages: number;
+  failedPages: number;
+  targets: CrossLinkTarget[];
+}
+
+interface CrawledPageLinks {
+  page: string;
+  ok: boolean;
+  linkedTargetSiteIds: string[];
+}
+
+function buildUnavailableTargets(
+  sourceSiteId: string,
+  managedSites: Site[],
+): CrossLinkTarget[] {
+  return managedSites
+    .filter((target) => target.id !== sourceSiteId)
+    .map((target) => ({
+      targetSiteId: target.id,
+      targetSiteName: target.name,
+      targetDomain: target.domain,
+      linkedPages: null,
+      missingPages: null,
+      linkedExamples: [],
+    }));
+}
+
+function normalizePageUrl(domain: string, page: string): string | null {
+  if (!page) return null;
+  try {
+    const url = new URL(page, `https://${domain}`);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function hostnameMatchesDomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function getBestMatchingManagedSite(hostname: string, managedSites: Site[]): Site | null {
+  let bestMatch: Site | null = null;
+
+  for (const site of managedSites) {
+    if (!hostnameMatchesDomain(hostname, site.domain)) continue;
+    if (!bestMatch || site.domain.length > bestMatch.domain.length) {
+      bestMatch = site;
+    }
+  }
+
+  return bestMatch;
+}
+
+function extractManagedLinkTargets(
+  html: string,
+  pageUrl: string,
+  sourceSiteId: string,
+  managedSites: Site[],
+): string[] {
+  const matches = html.match(/<a\b[^>]*\bhref=["']([^"'#]*?)["'][^>]*>/gi) || [];
+  const linkedSiteIds = new Set<string>();
+
+  for (const tag of matches) {
+    const hrefMatch = tag.match(/href=["']([^"'#]*?)["']/i);
+    if (!hrefMatch) continue;
+
+    const href = hrefMatch[1];
+    if (!href || href.startsWith('mailto:') || href.startsWith('javascript:')) continue;
+
+    let targetHostname: string | null = null;
+    try {
+      targetHostname = normalizeSiteDomain(new URL(href, pageUrl).hostname);
+    } catch {
+      targetHostname = null;
+    }
+
+    if (!targetHostname) continue;
+
+    const targetSite = getBestMatchingManagedSite(targetHostname, managedSites);
+    if (!targetSite || targetSite.id === sourceSiteId) continue;
+    linkedSiteIds.add(targetSite.id);
+  }
+
+  return [...linkedSiteIds];
+}
+
+async function fetchLinkedTargetsForPage(
+  site: Site,
+  pageUrl: string,
+  managedSites: Site[],
+): Promise<CrawledPageLinks> {
+  try {
+    const res = await fetch(pageUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'User-Agent': GOOGLEBOT_UA },
+    });
+
+    if (!res.ok) {
+      return { page: pageUrl, ok: false, linkedTargetSiteIds: [] };
+    }
+
+    const html = await res.text();
+    return {
+      page: pageUrl,
+      ok: true,
+      linkedTargetSiteIds: extractManagedLinkTargets(html, pageUrl, site.id, managedSites),
+    };
+  } catch (error) {
+    console.error(`Error crawling cross-links for ${site.id} ${pageUrl}:`, error);
+    return { page: pageUrl, ok: false, linkedTargetSiteIds: [] };
+  }
+}
+
+async function getCrossLinksForSourceSite(
+  site: Site,
+  managedSites: Site[],
+): Promise<CrossLinkSourceMatrix> {
+  if (site.searchConsole === false) {
+    return {
+      sourceSiteId: site.id,
+      sourceSiteName: site.name,
+      sourceDomain: site.domain,
+      status: 'disabled',
+      attemptedPages: 0,
+      crawledPages: 0,
+      failedPages: 0,
+      targets: buildUnavailableTargets(site.id, managedSites),
+    };
+  }
+
+  const topPages = await cachedGetSearchConsolePages(getSCUrl(site));
+  if (topPages === null) {
+    return {
+      sourceSiteId: site.id,
+      sourceSiteName: site.name,
+      sourceDomain: site.domain,
+      status: 'search-console-unavailable',
+      attemptedPages: 0,
+      crawledPages: 0,
+      failedPages: 0,
+      targets: buildUnavailableTargets(site.id, managedSites),
+    };
+  }
+
+  const pageUrls = (topPages ?? [])
+    .slice(0, 20)
+    .map((row) => normalizePageUrl(site.domain, row.page))
+    .filter((pageUrl): pageUrl is string => pageUrl !== null);
+
+  if (pageUrls.length === 0) {
+    return {
+      sourceSiteId: site.id,
+      sourceSiteName: site.name,
+      sourceDomain: site.domain,
+      status: 'no-pages',
+      attemptedPages: 0,
+      crawledPages: 0,
+      failedPages: 0,
+      targets: buildUnavailableTargets(site.id, managedSites),
+    };
+  }
+
+  const pageResults = await Promise.all(
+    pageUrls.map((pageUrl) => fetchLinkedTargetsForPage(site, pageUrl, managedSites)),
+  );
+  const crawledPages = pageResults.filter((page) => page.ok);
+  const failedPages = pageResults.length - crawledPages.length;
+
+  if (crawledPages.length === 0) {
+    return {
+      sourceSiteId: site.id,
+      sourceSiteName: site.name,
+      sourceDomain: site.domain,
+      status: 'crawl-unavailable',
+      attemptedPages: pageResults.length,
+      crawledPages: 0,
+      failedPages,
+      targets: buildUnavailableTargets(site.id, managedSites),
+    };
+  }
+
+  return {
+    sourceSiteId: site.id,
+    sourceSiteName: site.name,
+    sourceDomain: site.domain,
+    status: 'ok',
+    attemptedPages: pageResults.length,
+    crawledPages: crawledPages.length,
+    failedPages,
+    targets: managedSites
+      .filter((target) => target.id !== site.id)
+      .map((target) => {
+        const linkedExamples = crawledPages
+          .filter((page) => page.linkedTargetSiteIds.includes(target.id))
+          .map((page) => page.page)
+          .slice(0, 3);
+
+        return {
+          targetSiteId: target.id,
+          targetSiteName: target.name,
+          targetDomain: target.domain,
+          linkedPages: linkedExamples.length === 0
+            ? 0
+            : crawledPages.filter((page) => page.linkedTargetSiteIds.includes(target.id)).length,
+          missingPages: crawledPages.filter((page) => !page.linkedTargetSiteIds.includes(target.id)).length,
+          linkedExamples,
+        };
+      }),
+  };
+}
+
+export async function getCrossLinkMatrix(sites: Site[]): Promise<CrossLinkSourceMatrix[]> {
+  return Promise.all(
+    sites.map((site) => withCache<CrossLinkSourceMatrix>(
+      'cross-links-matrix',
+      site.id,
+      () => getCrossLinksForSourceSite(site, sites),
+      CROSS_LINK_TTL_MS,
+    )),
+  ).then((rows) => rows.filter((row): row is CrossLinkSourceMatrix => row !== null));
+}

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -1,4 +1,4 @@
-import { clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from './db';
+import { clearCache, clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from './db';
 import { getSCUrl, type Site } from './sites';
 
 const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-'] as const;
@@ -39,6 +39,8 @@ function shouldClearSitemapSyncState(
 export function invalidateManagedSiteCache(previousSite: Site | null, nextSite: Site | null): void {
   const previous = previousSite ? getCacheIdentities(previousSite) : null;
   const next = nextSite ? getCacheIdentities(nextSite) : null;
+
+  clearCache('cross-links-matrix');
 
   const auditSiteIds = unique([previous?.auditSiteId, next?.auditSiteId]);
 


### PR DESCRIPTION
Closes #41

Validated `#82` as already fixed, selected ready issue `#41`, created the TamTam issue branch, and implemented the cached cross-site link matrix plus UI surface.

---
Implemented via TamTam from issue [#41](https://github.com/3h4x/seo-tools/issues/41).