### PR TITLE
chore(review): lossy page join in low engagement gap

### DIFF
--- a/src/lib/__tests__/audit-page.test.tsx
+++ b/src/lib/__tests__/audit-page.test.tsx
@@ -311,6 +311,7 @@ describe('Audit page', () => {
     expect(dataTableCall![0].rowKeys).toEqual(['site-a:https://a.test/posts/alpha']);
 
     expect(html).toContain('Pages losing traffic · 30-day comparison');
+    expect(html).toContain('1 recommendation');
     expect(html).toContain('1234ms');
     expect(html).toContain('RUM');
     expect(html).toContain('Checked moments ago');

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -163,6 +163,23 @@ describe('analyzeSiteGaps', () => {
     expect(gap?.description).toContain('54 Search Console clicks');
   });
 
+  it('does not merge distinct case-sensitive SC paths when scoring low-engagement traffic', () => {
+    const result = analyzeSiteGaps(makeAudit(), makeSite(), {
+      days: 30,
+      ga4TopPages: [
+        { path: '/pricing', views: 300, users: 180, engagementRate: 0.32, avgSessionDuration: 42 },
+      ],
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 30, impressions: 400, ctr: 0.075, position: 4.1 },
+        { page: 'https://example.com/Pricing', clicks: 30, impressions: 320, ctr: 0.09375, position: 3.4 },
+      ],
+    });
+
+    const gap = result.gaps.find((candidate) => candidate.id === 'low-engagement-despite-traffic');
+
+    expect(gap).toBeUndefined();
+  });
+
   it('maps low-engagement-despite-traffic into the content section', () => {
     const result = analyzeSiteGaps(makeAudit(), makeSite(), {
       days: 30,

--- a/src/lib/gaps.ts
+++ b/src/lib/gaps.ts
@@ -83,11 +83,11 @@ function normalizePageKey(value: string): string {
       ? new URL(value)
       : new URL(value, 'https://placeholder.local');
     const pathname = url.pathname.replace(/\/+$/, '') || '/';
-    return pathname.toLowerCase();
+    return pathname;
   } catch {
     const trimmed = value.split('?')[0]?.split('#')[0] ?? value;
     const normalized = trimmed.replace(/\/+$/, '') || '/';
-    return normalized.toLowerCase();
+    return normalized;
   }
 }
 


### PR DESCRIPTION
Closes #89

Validated issue #89 against current `HEAD`, branched via TamTam, implemented the case-sensitive page-join fix, and updated agent memory.

---
Implemented via TamTam from issue [#89](https://github.com/3h4x/seo-tools/issues/89).