### PR TITLE
fix: Detect broken internal links during audit so crawlability issues surface per-site

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -554,11 +554,31 @@ export default async function SiteDashboardPage({
           <AuditPanel title={`Internal Links · ${audit.internalLinks.length} pages checked`}>
             <div className="space-y-3">
               {audit.internalLinks.map((link, i) => (
-                <div key={i} className="flex items-center gap-4 text-xs">
-                  <div className={`size-1.5 rounded-full shrink-0 ${statusDots[link.status]}`} />
-                  <span className="text-neutral-400 font-mono w-32 shrink-0">{link.page}</span>
-                  <span className="text-neutral-300 font-mono">{link.internalLinks} internal</span>
-                  <span className="text-neutral-500 font-mono">{link.externalLinks} external</span>
+                <div key={i} className="rounded border border-neutral-800 bg-neutral-950/40 p-3">
+                  <div className="flex flex-wrap items-center gap-4 text-xs">
+                    <div className={`size-1.5 rounded-full shrink-0 ${statusDots[link.status]}`} />
+                    <span className="text-neutral-400 font-mono w-32 shrink-0">{link.page}</span>
+                    <span className="text-neutral-300 font-mono">{link.internalLinks} internal</span>
+                    <span className="text-neutral-500 font-mono">{link.externalLinks} external</span>
+                    <span className="text-neutral-600 font-mono">{link.brokenLinksMessage}</span>
+                    {link.brokenLinks.length > 0 && (
+                      <span className="text-red-400 font-mono">{link.brokenLinks.length} broken</span>
+                    )}
+                  </div>
+                  {link.brokenLinks.length > 0 && (
+                    <details className="mt-3">
+                      <summary className="cursor-pointer text-xs text-red-400 font-mono">
+                        Show broken internal URLs
+                      </summary>
+                      <div className="mt-2 space-y-1">
+                        {link.brokenLinks.map((brokenLink) => (
+                          <div key={`${link.page}-${brokenLink.url}`} className="text-[11px] font-mono text-neutral-500 break-all">
+                            <span className="text-red-400">HTTP {brokenLink.status || 0}</span> {brokenLink.url}
+                          </div>
+                        ))}
+                      </div>
+                    </details>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/lib/__tests__/audit-async.test.ts
+++ b/src/lib/__tests__/audit-async.test.ts
@@ -544,9 +544,7 @@ describe('auditSite — skipChecks', () => {
   });
 
   it('matches identifier-style skip keys for OG image and internal links', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockImplementation((url: string) => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
         const u = String(url);
         if (u.endsWith('/favicon.ico')) {
           return makeResponse({ status: 404, body: 'missing' });
@@ -560,14 +558,86 @@ describe('auditSite — skipChecks', () => {
         return makeResponse({
           body: '<html><head><title>Test</title></head><body><img src="/hero.jpg"><a href="/about">About</a></body></html>',
         });
-      }),
-    );
+      });
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await cachedAuditSite(makeSite({ skipChecks: ['ogImage', 'internalLinks'] }));
     expect(result.ogImage.status).toBe('pass');
     expect(result.ogImage.message).toContain('N/A');
     expect(result.internalLinks[0].status).toBe('pass');
     expect(result.internalLinks[0].message).toContain('N/A');
+    expect(result.internalLinks[0].brokenLinks).toEqual([]);
+    expect(result.internalLinks[0].brokenLinksMessage).toContain('N/A');
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => String(url).endsWith('/about') && (init as RequestInit | undefined)?.method === 'HEAD'),
+    ).toBe(false);
+  });
+
+  it('supports the broken-links skip alias without skipping internal link counts', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const u = String(url);
+        const method = init?.method ?? 'GET';
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+        }
+        if (u.endsWith('/missing') && method === 'HEAD') {
+          return makeResponse({ status: 404 });
+        }
+        return makeResponse({
+          body: '<html><head><title>Test</title></head><body><a href="/about">About</a><a href="/missing">Missing</a><a href="/contact">Contact</a></body></html>',
+        });
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await cachedAuditSite(makeSite({ skipChecks: ['broken-links'] }));
+    expect(result.internalLinks[0].internalLinks).toBe(3);
+    expect(result.internalLinks[0].status).toBe('pass');
+    expect(result.internalLinks[0].checkedInternalLinks).toBe(0);
+    expect(result.internalLinks[0].brokenLinks).toEqual([]);
+    expect(result.internalLinks[0].brokenLinksMessage).toContain('N/A');
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => {
+        const target = String(url);
+        const method = (init as RequestInit | undefined)?.method ?? 'GET';
+        return (target.endsWith('/about') || target.endsWith('/missing') || target.endsWith('/contact')) &&
+          (method === 'HEAD' || method === 'GET');
+      }),
+    ).toBe(false);
+  });
+
+  it('removes broken-link penalties when internal links are skipped', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u.endsWith('/robots.txt')) {
+        return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+      }
+      if (u.endsWith('/sitemap.xml')) {
+        return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+      }
+      if (u.endsWith('/missing') && method === 'HEAD') {
+        return makeResponse({ status: 404 });
+      }
+      return makeResponse({
+        body: '<html><head><title>Test</title></head><body><a href="/about">About</a><a href="/missing">Missing</a><a href="/contact">Contact</a></body></html>',
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const baseline = await cachedAuditSite(makeSite());
+    const skipped = await cachedAuditSite(makeSite({ skipChecks: ['internalLinks'] }));
+
+    expect(baseline.internalLinks[0].brokenLinks).toEqual([{ url: 'https://example.com/missing', status: 404 }]);
+    expect(skipped.internalLinks[0].status).toBe('pass');
+    expect(skipped.internalLinks[0].brokenLinks).toEqual([]);
+    expect(skipped.internalLinks[0].brokenLinksMessage).toContain('N/A');
+    expect(skipped.score.fail).toBe(baseline.score.fail - 1);
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => String(url).endsWith('/missing') && (init as RequestInit | undefined)?.method === 'HEAD'),
+    ).toBe(true);
   });
 
   it('keeps og:image meta skips separate from the OG Image asset check', async () => {
@@ -721,6 +791,124 @@ describe('auditSite — canonical', () => {
     expect(result.metaTags[0].canonical.status).toBe('fail');
     expect(result.metaTags[0].canonicalStatus).toBe(404);
     expect(result.metaTags[0].canonical.message).toContain('HTTP 404');
+  });
+});
+
+describe('auditSite — broken internal links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSitemapsList.mockResolvedValue({ data: { sitemap: [] } });
+    mockSearchAnalyticsQuery.mockResolvedValue({ data: { rows: [] } });
+  });
+
+  it('checks up to 20 unique internal links and records broken targets', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const u = String(url);
+        const method = init?.method ?? 'GET';
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+        }
+        if (method === 'HEAD' && u.endsWith('/missing-a')) {
+          return makeResponse({ status: 404 });
+        }
+        if (method === 'HEAD' && u.endsWith('/missing-b')) {
+          return makeResponse({ status: 500 });
+        }
+        if (method === 'HEAD' && u.startsWith('https://example.com/page-')) {
+          return makeResponse({ status: 200 });
+        }
+
+        return makeResponse({
+          body: [
+            '<html><head><title>Test</title></head><body>',
+            '<a href="/page-1">One</a>',
+            '<a href="/page-2">Two</a>',
+            '<a href="/page-3">Three</a>',
+            '<a href="/page-4">Four</a>',
+            '<a href="/page-5">Five</a>',
+            '<a href="/page-6">Six</a>',
+            '<a href="/page-7">Seven</a>',
+            '<a href="/page-8">Eight</a>',
+            '<a href="/page-9">Nine</a>',
+            '<a href="/page-10">Ten</a>',
+            '<a href="/page-11">Eleven</a>',
+            '<a href="/page-12">Twelve</a>',
+            '<a href="/page-13">Thirteen</a>',
+            '<a href="/page-14">Fourteen</a>',
+            '<a href="/page-15">Fifteen</a>',
+            '<a href="/page-16">Sixteen</a>',
+            '<a href="/page-17">Seventeen</a>',
+            '<a href="/page-18">Eighteen</a>',
+            '<a href="/missing-a">Missing A</a>',
+            '<a href="/missing-b">Missing B</a>',
+            '<a href="/page-19">Nineteen</a>',
+            '<a href="/page-20">Twenty</a>',
+            '<a href="/page-21">Twenty One</a>',
+            '</body></html>',
+          ].join(''),
+        });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.internalLinks[0].checkedInternalLinks).toBe(20);
+    expect(result.internalLinks[0].brokenLinks).toEqual([
+      { url: 'https://example.com/missing-a', status: 404 },
+      { url: 'https://example.com/missing-b', status: 500 },
+    ]);
+    expect(result.internalLinks[0].brokenLinksMessage).toContain('2 broken');
+    expect(result.score.fail).toBeGreaterThanOrEqual(2);
+  });
+
+  it('verifies internal links with bounded concurrency instead of one-by-one', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const u = String(url);
+        const method = init?.method ?? 'GET';
+        if (u.endsWith('/robots.txt')) {
+          return makeResponse({ body: 'Sitemap: https://example.com/sitemap.xml\n' });
+        }
+        if (u.endsWith('/sitemap.xml')) {
+          return makeResponse({ body: '<urlset><url><loc>https://example.com/</loc></url></urlset>' });
+        }
+        if (method === 'HEAD' && u.startsWith('https://example.com/page-')) {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              inFlight--;
+              resolve(makeResponse({ status: 200 }));
+            }, 20);
+          });
+        }
+
+        return makeResponse({
+          body: [
+            '<html><head><title>Test</title></head><body>',
+            '<a href="/page-1">One</a>',
+            '<a href="/page-2">Two</a>',
+            '<a href="/page-3">Three</a>',
+            '<a href="/page-4">Four</a>',
+            '<a href="/page-5">Five</a>',
+            '<a href="/page-6">Six</a>',
+            '</body></html>',
+          ].join(''),
+        });
+      }),
+    );
+
+    const result = await cachedAuditSite(makeSite());
+    expect(result.internalLinks[0].checkedInternalLinks).toBe(6);
+    expect(maxInFlight).toBeGreaterThan(1);
   });
 });
 

--- a/src/lib/__tests__/audit-helpers.test.ts
+++ b/src/lib/__tests__/audit-helpers.test.ts
@@ -309,6 +309,8 @@ describe('checkInternalLinks', () => {
     const result = checkInternalLinks('<a href="/a">A</a><a href="/b">B</a><a href="/c">C</a>', domain, '/test');
     expect(result.page).toBe('/test');
     expect(result.label).toBe('Internal Links');
+    expect(result.checkedInternalLinks).toBe(0);
+    expect(result.brokenLinks).toEqual([]);
   });
 });
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -103,6 +103,12 @@ interface InternalLinkResult {
   page: string;
   internalLinks: number;
   externalLinks: number;
+  checkedInternalLinks: number;
+  brokenLinks: Array<{
+    url: string;
+    status: number;
+  }>;
+  brokenLinksMessage: string;
   status: CheckStatus;
   label: string;
   message: string;
@@ -152,12 +158,20 @@ export function normalizeSiteAuditResult(audit: SiteAuditResult): SiteAuditResul
   return {
     ...audit,
     redirectChains: audit.redirectChains ?? [],
+    internalLinks: (audit.internalLinks ?? []).map((link) => ({
+      ...link,
+      checkedInternalLinks: link.checkedInternalLinks ?? 0,
+      brokenLinks: link.brokenLinks ?? [],
+      brokenLinksMessage: link.brokenLinksMessage ?? 'Broken-link verification unavailable in cached audit',
+    })),
   };
 }
 
 export const MAX_SAMPLED_PAGES = 10;
 const SITEMAP_SAMPLE_LIMIT = 5;
 const SC_SAMPLE_LIMIT = 5;
+const INTERNAL_LINK_HEALTH_LIMIT = 20;
+const INTERNAL_LINK_HEALTH_CONCURRENCY = 5;
 
 export function extractLocsFromSitemap(xml: string): string[] {
   return [...xml.matchAll(/<loc>([^<]+)<\/loc>/gi)].map(m => m[1].trim());
@@ -174,6 +188,29 @@ function summarizeStatuses(statuses: CheckStatus[]): CheckStatus {
   if (statuses.includes('warn')) return 'warn';
   if (statuses.includes('error')) return 'error';
   return 'pass';
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runWorker() {
+    while (true) {
+      const currentIndex = nextIndex++;
+      if (currentIndex >= items.length) return;
+      results[currentIndex] = await worker(items[currentIndex], currentIndex);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
 }
 
 function extractInternalPagePaths(html: string, domain: string): string[] {
@@ -272,6 +309,20 @@ async function getUrlHealthStatus(url: string): Promise<number> {
   }
 
   const getRes = await safeFetch(url, { ua: GOOGLEBOT_UA });
+  return getRes.status;
+}
+
+async function getInternalLinkHealthStatus(url: string): Promise<number> {
+  const headRes = await safeFetch(url, {
+    method: 'HEAD',
+    ua: GOOGLEBOT_UA,
+    timeoutMs: 5_000,
+  });
+  if (headRes.status !== 405 && headRes.status !== 501 && headRes.status !== 0) {
+    return headRes.status;
+  }
+
+  const getRes = await safeFetch(url, { ua: GOOGLEBOT_UA, timeoutMs: 5_000 });
   return getRes.status;
 }
 
@@ -790,8 +841,46 @@ export function checkInternalLinks(html: string, domain: string, page: string): 
 
   return {
     page, internalLinks, externalLinks, status,
+    checkedInternalLinks: 0,
+    brokenLinks: [],
+    brokenLinksMessage: 'Broken-link verification unavailable',
     label: 'Internal Links',
     message: `${internalLinks} internal, ${externalLinks} external`,
+  };
+}
+
+async function enrichInternalLinkResult(html: string, domain: string, page: string): Promise<InternalLinkResult> {
+  const base = checkInternalLinks(html, domain, page);
+  const internalPaths = extractInternalPagePaths(html, domain).slice(0, INTERNAL_LINK_HEALTH_LIMIT);
+
+  if (internalPaths.length === 0) {
+    return {
+      ...base,
+      checkedInternalLinks: 0,
+      brokenLinksMessage: 'No internal links to verify',
+    };
+  }
+
+  const linkStatuses = await mapWithConcurrency(
+    internalPaths,
+    INTERNAL_LINK_HEALTH_CONCURRENCY,
+    async (path) => {
+      const url = `https://${domain}${path}`;
+      const status = await getInternalLinkHealthStatus(url);
+      return { url, status };
+    },
+  );
+
+  const brokenLinks = linkStatuses.filter(({ status }) => status >= 400 || status === 0);
+
+  return {
+    ...base,
+    checkedInternalLinks: internalPaths.length,
+    brokenLinks,
+    brokenLinksMessage:
+      brokenLinks.length === 0
+        ? `Checked ${internalPaths.length} unique internal link${internalPaths.length === 1 ? '' : 's'}`
+        : `Checked ${internalPaths.length} unique internal link${internalPaths.length === 1 ? '' : 's'} · ${brokenLinks.length} broken`,
   };
 }
 
@@ -1205,6 +1294,8 @@ async function fetchScTopPageUrls(site: Site): Promise<string[]> {
 }
 
 async function auditSite(site: Site): Promise<SiteAuditResult> {
+  const skip = new Set(normalizeSkipChecks(site.skipChecks));
+  const shouldVerifyBrokenLinks = !skip.has('internalLinks') && !skip.has('brokenLinks');
   const robotsTxt = await checkRobotsTxt(site.domain);
 
   const [rawSitemap, ttfb, security, scSitemapFreshness, scTopPageUrls] = await Promise.all([
@@ -1244,7 +1335,21 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
       redirectChain,
       meta,
       images: res.ok ? checkImageSeo(res.text, page) : { page, totalImages: 0, withAlt: 0, withoutAlt: 0, withLazyLoading: 0, status: 'error' as CheckStatus, label: 'Images', message: res.error || `HTTP ${res.status}`, images: [] },
-      links: res.ok ? checkInternalLinks(res.text, site.domain, page) : { page, internalLinks: 0, externalLinks: 0, status: 'error' as CheckStatus, label: 'Internal Links', message: res.error || `HTTP ${res.status}` },
+      links: res.ok
+        ? shouldVerifyBrokenLinks
+          ? await enrichInternalLinkResult(res.text, site.domain, page)
+          : checkInternalLinks(res.text, site.domain, page)
+        : {
+            page,
+            internalLinks: 0,
+            externalLinks: 0,
+            checkedInternalLinks: 0,
+            brokenLinks: [],
+            brokenLinksMessage: res.error || `HTTP ${res.status}`,
+            status: 'error' as CheckStatus,
+            label: 'Internal Links',
+            message: res.error || `HTTP ${res.status}`,
+          },
     });
   }
 
@@ -1257,7 +1362,6 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   const ogImage = await checkOgImage(ogImageUrl);
 
   // Apply skipChecks: replace skipped checks with a neutral pass so they don't affect the score
-  const skip = new Set(normalizeSkipChecks(site.skipChecks));
   const skippedRobotsTxt = applySkipToCheck(robotsTxt, skip, 'robotsTxt');
   const skippedSitemap = applySkipToCheck(sitemap, skip, 'sitemap');
   const skippedScSitemapFreshness = applySkipToCheck(scSitemapFreshness, skip, 'scSitemap');
@@ -1282,7 +1386,29 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     jsonLd: applySkipToCheck(meta.jsonLd, skip, 'jsonLd'),
   }));
   const skippedImageSeo = imageSeo.map(image => applySkipToCheck(image, skip, 'images'));
-  const skippedInternalLinks = internalLinks.map(link => applySkipToCheck(link, skip, 'internalLinks'));
+  const shouldSkipBrokenLinkReporting = skip.has('internalLinks') || skip.has('brokenLinks');
+  const skippedInternalLinks = internalLinks.map(link => {
+    const skippedLink = applySkipToCheck(link, skip, 'internalLinks');
+    if (shouldSkipBrokenLinkReporting) {
+      return {
+        ...skippedLink,
+        checkedInternalLinks: 0,
+        brokenLinks: [],
+        brokenLinksMessage: 'N/A — broken-link verification skipped',
+      };
+    }
+    return skippedLink;
+  });
+
+  const brokenLinkPenaltyChecks = shouldSkipBrokenLinkReporting
+    ? []
+    : skippedInternalLinks.flatMap((link) =>
+        link.brokenLinks.map((brokenLink) => ({
+          status: 'fail' as const,
+          label: 'Broken Link',
+          message: `${link.page} -> ${brokenLink.url} (${brokenLink.status || 'timeout'})`,
+        })),
+      );
 
   const allChecks: CheckResult[] = [
     skippedRobotsTxt,
@@ -1298,6 +1424,7 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
     ...skippedMetaTags.flatMap(m => [m.title, m.description, m.ogTitle, m.ogImage, m.ogDescription, m.twitterCard, m.canonical, m.jsonLd]),
     ...skippedImageSeo,
     ...skippedInternalLinks,
+    ...brokenLinkPenaltyChecks,
   ];
 
   const score = allChecks.reduce(

--- a/src/lib/skip-checks.ts
+++ b/src/lib/skip-checks.ts
@@ -18,6 +18,7 @@ export type SkipCheckId =
   | 'favicon'
   | 'ttfb'
   | 'images'
+  | 'brokenLinks'
   | 'internalLinks';
 
 export interface SkipCheckOption {
@@ -46,6 +47,7 @@ export const SKIP_CHECK_OPTIONS: SkipCheckOption[] = [
   { id: 'favicon', label: 'Favicon' },
   { id: 'ttfb', label: 'TTFB' },
   { id: 'images', label: 'Images' },
+  { id: 'brokenLinks', label: 'Broken Links', aliases: ['broken-links'] },
   { id: 'internalLinks', label: 'Internal Links' },
 ];
 


### PR DESCRIPTION
Closes #27

Validated `#27` against current `HEAD`, commented on the issue, created the TamTam issue branch, and implemented broken internal-link detection plus UI surfacing.

---
Implemented via TamTam from issue [#27](https://github.com/3h4x/seo-tools/issues/27).