### PR TITLE
fix: Cross-reference noindex directives with SC click data so accidentally-noindexed ranking pages surface immediately

### DIFF
--- a/app/[site]/page.tsx
+++ b/app/[site]/page.tsx
@@ -404,7 +404,7 @@ export default async function SiteDashboardPage({
             )}
           </CheckCard>
           <CheckCard check={audit.scSitemapFreshness} />
-          <CheckCard check={audit.indexingCoverage}>
+          <CheckCard check={audit.indexingCoverage} gaps={sections['indexing']}>
             {audit.indexingCoverage.sitemapUrls != null && audit.indexingCoverage.indexedPages != null && (
               <div className="mt-3">
                 <div className="flex items-center gap-4 text-xs text-neutral-400 mb-2">
@@ -664,11 +664,6 @@ export default async function SiteDashboardPage({
                 })}
               </div>
             </div>
-          )}
-          {sections['indexing'] && sections['indexing'].length > 0 && (
-            <AuditPanel title="Indexing">
-              {sections['indexing'].map(g => <Recommendation key={g.id} gap={g} />)}
-            </AuditPanel>
           )}
           {sections['other'] && sections['other'].length > 0 && (
             <AuditPanel title="Additional Recommendations">

--- a/app/components/audit/check-card.tsx
+++ b/app/components/audit/check-card.tsx
@@ -45,6 +45,15 @@ export function Recommendation({ gap }: { gap: GapRecommendation }) {
       </div>
       <p className="text-neutral-300 text-sm font-medium">{gap.title}</p>
       <p className="text-neutral-500 text-xs mt-1">{gap.description}</p>
+      {gap.evidence && gap.evidence.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {gap.evidence.map((line) => (
+            <div key={line} className="text-neutral-400 text-xs font-mono break-all">
+              {line}
+            </div>
+          ))}
+        </div>
+      )}
       <details className="mt-2">
         <summary className="text-neutral-500 text-xs cursor-pointer hover:text-neutral-300 transition-colors">How to fix</summary>
         <pre className="text-neutral-400 text-xs font-mono mt-1.5 whitespace-pre-wrap">{gap.hint}</pre>

--- a/app/components/gaps-client.tsx
+++ b/app/components/gaps-client.tsx
@@ -30,6 +30,15 @@ function GapRow({ sg }: { sg: SiteGap }) {
             <span className="text-white font-semibold text-sm">{gap.title}</span>
           </div>
           <p className="text-neutral-500 text-xs mt-1">{gap.description}</p>
+          {gap.evidence && gap.evidence.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {gap.evidence.map((line) => (
+                <div key={line} className="text-neutral-400 text-xs font-mono break-all">
+                  {line}
+                </div>
+              ))}
+            </div>
+          )}
           <details className="mt-2 group">
             <summary className="text-neutral-500 text-xs cursor-pointer hover:text-neutral-300 transition-colors list-none flex items-center gap-1">
               <span className="group-open:hidden">▸ How to fix</span>

--- a/src/lib/__tests__/audit-helpers.test.ts
+++ b/src/lib/__tests__/audit-helpers.test.ts
@@ -182,6 +182,34 @@ describe('parseMetaTags', () => {
     const result = parseMetaTags(res, '/');
     expect(result.ogImageUrl).toBe('https://example.com/og.png');
   });
+
+  it('records noindex when robots directives include it', () => {
+    const res = makeFetchResult({
+      text: '<html><head><title>Test</title><meta name="robots" content="index, noindex"></head></html>',
+    });
+    const result = parseMetaTags(res, '/');
+    expect(result.noindex).toBe(true);
+  });
+
+  it('records noindex when X-Robots-Tag header includes it', () => {
+    const headers = new Headers({ 'x-robots-tag': 'googlebot: noindex, nofollow' });
+    const res = makeFetchResult({
+      text: '<html><head><title>Test</title></head></html>',
+      headers,
+    });
+    const result = parseMetaTags(res, '/');
+    expect(result.noindex).toBe(true);
+  });
+
+  it('ignores X-Robots-Tag noindex directives scoped to non-Google bots', () => {
+    const headers = new Headers({ 'x-robots-tag': 'otherbot: noindex, nofollow' });
+    const res = makeFetchResult({
+      text: '<html><head><title>Test</title></head></html>',
+      headers,
+    });
+    const result = parseMetaTags(res, '/');
+    expect(result.noindex).toBe(false);
+  });
 });
 
 describe('checkImageSeo', () => {

--- a/src/lib/__tests__/canonical.test.ts
+++ b/src/lib/__tests__/canonical.test.ts
@@ -14,6 +14,7 @@ function makeMetaTag(
   return {
     page: overrides.page ?? '/',
     ogImageUrl: undefined,
+    noindex: false,
     canonicalValid: overrides.canonicalValid ?? null,
     canonicalStatus: overrides.canonicalHttpStatus ?? null,
     canonicalTarget: overrides.canonicalTarget ?? null,

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { analyzeSiteGaps, gapsBySection } from '../gaps';
-import type { SiteAuditResult } from '../audit';
+import { parseMetaTags, type FetchResult, type SiteAuditResult } from '../audit';
 import type { Site } from '../sites';
 import { getSkipCheckId } from '../skip-checks';
 
@@ -8,9 +8,10 @@ function makeCheckResult(status: 'pass' | 'warn' | 'fail' | 'error', label: stri
   return { status, label, message: `${status} result` };
 }
 
-function makeMetaTagResult(page: string, overrides: Record<string, ReturnType<typeof makeCheckResult>> = {}) {
+function makeMetaTagResult(page: string, overrides: Record<string, unknown> = {}) {
   return {
     page,
+    noindex: false,
     canonicalValid: null,
     canonicalStatus: null,
     canonicalTarget: null,
@@ -194,6 +195,105 @@ describe('analyzeSiteGaps', () => {
     const sections = gapsBySection(result.gaps);
 
     expect(sections.content?.map((gap) => gap.id)).toContain('low-engagement-despite-traffic');
+  });
+
+  it('emits noindex-but-ranking when a noindexed page still has Search Console clicks', () => {
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [makeMetaTagResult('/pricing', { noindex: true })],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    const gap = result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking');
+    expect(gap).toBeDefined();
+    expect(gap?.severity).toBe('high');
+    expect(gap?.affectedPages).toEqual(['https://example.com/pricing']);
+    expect(gap?.evidence).toEqual(['https://example.com/pricing · 24 clicks · 240 impressions']);
+  });
+
+  it('emits noindex-but-ranking when noindex comes from X-Robots-Tag', () => {
+    const metaFromHeader = parseMetaTags({
+      ok: true,
+      status: 200,
+      text: '<html><head><title>Pricing</title></head></html>',
+      headers: new Headers({ 'x-robots-tag': 'googlebot: noindex, nofollow' }),
+      ttfbMs: 50,
+    } satisfies FetchResult, '/pricing');
+
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [metaFromHeader],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    expect(result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking')).toBeDefined();
+  });
+
+  it('does not emit noindex-but-ranking when X-Robots-Tag noindex targets a different bot', () => {
+    const metaFromHeader = parseMetaTags({
+      ok: true,
+      status: 200,
+      text: '<html><head><title>Pricing</title></head></html>',
+      headers: new Headers({ 'x-robots-tag': 'otherbot: noindex, nofollow' }),
+      ttfbMs: 50,
+    } satisfies FetchResult, '/pricing');
+
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [metaFromHeader],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    expect(result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking')).toBeUndefined();
+  });
+
+  it('dedupes slash variants when the same noindexed page is sampled twice', () => {
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [
+        makeMetaTagResult('/pricing', { noindex: true }),
+        makeMetaTagResult('/pricing/', { noindex: true }),
+      ],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    const gap = result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking');
+    expect(gap).toBeDefined();
+    expect(gap?.affectedPages).toEqual(['https://example.com/pricing']);
+    expect(gap?.evidence).toEqual(['https://example.com/pricing · 24 clicks · 240 impressions']);
+    expect(gap?.description).toContain('1 noindexed page');
+  });
+
+  it('does not emit noindex-but-ranking when a noindexed page has no Search Console traffic', () => {
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [makeMetaTagResult('/pricing', { noindex: true })],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/docs', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    expect(result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking')).toBeUndefined();
+  });
+
+  it('does not emit noindex-but-ranking when a ranking page is indexable', () => {
+    const result = analyzeSiteGaps(makeAudit({
+      metaTags: [makeMetaTagResult('/pricing')],
+    }), makeSite(), {
+      scTopPages: [
+        { page: 'https://example.com/pricing', clicks: 24, impressions: 240, ctr: 0.1, position: 4.2 },
+      ],
+    });
+
+    expect(result.gaps.find((candidate) => candidate.id === 'noindex-but-ranking')).toBeUndefined();
   });
 
   it('includes redirect-chains gap for unskipped redirect chain failures', () => {

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -182,10 +182,24 @@ vi.mock('../../../app/components/metric-card', () => ({
 }));
 
 vi.mock('../../../app/components/audit/check-card', () => ({
-  CheckCard: ({ check, children }: { check: { label: string; message: string }; children?: React.ReactNode }) => (
+  CheckCard: ({
+    check,
+    gaps,
+    children,
+  }: {
+    check: { label: string; message: string };
+    gaps?: Array<{ title: string; hint: string }>;
+    children?: React.ReactNode;
+  }) => (
     <div>
       <div>{check.label}</div>
       <div>{check.message}</div>
+      {gaps?.map((gap) => (
+        <div key={gap.title}>
+          <div>{gap.title}</div>
+          <div>{gap.hint}</div>
+        </div>
+      ))}
       {children}
     </div>
   ),
@@ -419,6 +433,7 @@ describe('SiteDashboardPage', () => {
       ...makeAuditResult(),
       metaTags: [{
         page: '/',
+        noindex: false,
         canonicalValid: true,
         canonicalStatus: 200,
         canonicalTarget: 'https://site-one.test/',
@@ -448,6 +463,7 @@ describe('SiteDashboardPage', () => {
       ...makeAuditResult(),
       metaTags: [{
         page: '/',
+        noindex: false,
         canonicalValid: null,
         canonicalStatus: null,
         canonicalTarget: null,
@@ -509,6 +525,29 @@ describe('SiteDashboardPage', () => {
         days: 30,
       },
     );
+  });
+
+  it('renders indexing gaps through the shared recommendation path', async () => {
+    mockGapsBySection.mockReturnValue({
+      indexing: [{
+        id: 'noindex-but-ranking',
+        title: 'Remove accidental noindex from ranking pages',
+        description: '1 noindexed page still receives Search Console clicks.',
+        severity: 'high',
+        category: 'indexing',
+        hint: 'Remove the noindex directive from the rendered HTML or X-Robots-Tag response header.',
+        evidence: ['https://site-one.test/pricing · 24 clicks · 240 impressions'],
+      }],
+    });
+
+    const html = renderToStaticMarkup(await SiteDashboardPage({
+      params: Promise.resolve({ site: 'site-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(html).toContain('Remove accidental noindex from ranking pages');
+    expect(html).toContain('X-Robots-Tag response header');
+    expect(html.match(/Remove accidental noindex from ranking pages/g)).toHaveLength(1);
   });
 
   it('renders the low-engagement recommendation alongside the summary count', async () => {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -41,6 +41,7 @@ interface SitemapResult extends CheckResult {
 interface MetaTagResult {
   page: string;
   ogImageUrl?: string;
+  noindex: boolean;
   canonicalValid: boolean | null;
   canonicalStatus: number | null;
   canonicalTarget: string | null;
@@ -604,11 +605,43 @@ export function makeCheck(label: string, value: string | null, minLen: number = 
 
 const GENERIC_TITLES = ['react app', 'vite app', 'document', 'untitled', 'home', 'index'];
 
+function hasNoindexDirective(value: string | null | undefined): boolean {
+  return value ? /\b(?:noindex|none)\b/i.test(value) : false;
+}
+
+function xRobotsTagHasApplicableNoindex(value: string | null | undefined): boolean {
+  if (!value) return false;
+
+  let activeScope: 'generic' | 'googlebot' | 'other' = 'generic';
+
+  for (const part of value.split(',')) {
+    const token = part.trim();
+    if (!token) continue;
+
+    const scopedDirective = token.match(/^([^:]+):\s*(.+)$/);
+    if (scopedDirective) {
+      const scope = scopedDirective[1].trim().toLowerCase();
+      activeScope = scope === 'googlebot' ? 'googlebot' : 'other';
+      if (activeScope === 'googlebot' && hasNoindexDirective(scopedDirective[2])) {
+        return true;
+      }
+      continue;
+    }
+
+    if ((activeScope === 'generic' || activeScope === 'googlebot') && hasNoindexDirective(token)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   if (!res.ok) {
     const errResult: CheckResult = { status: 'error', label: '', message: res.error || `HTTP ${res.status}` };
     return {
       page,
+      noindex: false,
       canonicalValid: null,
       canonicalStatus: null,
       canonicalTarget: null,
@@ -634,6 +667,10 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   const ogImage = extractMeta(html, 'og:image');
   const ogDesc = extractMeta(html, 'og:description');
   const twitterCard = extractMeta(html, 'twitter:card', 'name') || extractMeta(html, 'twitter:card');
+  const robotsDirectives = [extractMeta(html, 'robots', 'name'), extractMeta(html, 'googlebot', 'name')]
+    .filter((value): value is string => Boolean(value));
+  const xRobotsTag = res.headers.get('x-robots-tag');
+  const noindex = robotsDirectives.some(hasNoindexDirective) || xRobotsTagHasApplicableNoindex(xRobotsTag);
 
   const canonicalMatch = html.match(/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']*?)["'][^>]*>/i);
   const canonical = canonicalMatch?.[1] ?? null;
@@ -651,6 +688,7 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   return {
     page,
     ogImageUrl: ogImage || undefined,
+    noindex,
     canonicalValid: null,
     canonicalStatus: null,
     canonicalTarget: canonical,

--- a/src/lib/gaps.ts
+++ b/src/lib/gaps.ts
@@ -33,6 +33,7 @@ export interface GapRecommendation {
   category: GapCategory;
   hint: string;
   affectedPages?: string[];
+  evidence?: string[];
 }
 
 interface SiteGapAnalysis {
@@ -92,6 +93,7 @@ function normalizePageKey(value: string): string {
 }
 
 interface AggregatedScPageSignal {
+  page: string;
   clicks: number;
   impressions: number;
   ctr: number;
@@ -109,6 +111,7 @@ function aggregateScTopPages(scTopPages: SCPageRow[]): Map<string, AggregatedScP
       const totalClicks = existing.clicks + page.clicks;
       const totalImpressions = existing.impressions + page.impressions;
       aggregated.set(key, {
+        page: existing.page,
         clicks: totalClicks,
         impressions: totalImpressions,
         ctr: totalImpressions > 0
@@ -120,6 +123,7 @@ function aggregateScTopPages(scTopPages: SCPageRow[]): Map<string, AggregatedScP
     }
 
     aggregated.set(key, {
+      page: page.page,
       clicks: page.clicks,
       impressions: page.impressions,
       ctr: page.ctr,
@@ -128,6 +132,45 @@ function aggregateScTopPages(scTopPages: SCPageRow[]): Map<string, AggregatedScP
   }
 
   return aggregated;
+}
+
+function toAbsolutePageUrl(page: string, domain: string): string {
+  if (page.startsWith('http://') || page.startsWith('https://')) return page;
+  const normalizedPage = page.startsWith('/') ? page : `/${page}`;
+  return `https://${domain}${normalizedPage}`;
+}
+
+interface NoindexConflict {
+  page: string;
+  clicks: number;
+  impressions: number;
+}
+
+function getNoindexButRankingPages(
+  audit: SiteAuditResult,
+  scTopPages: SCPageRow[],
+  domain: string,
+): NoindexConflict[] {
+  const scByPage = aggregateScTopPages(scTopPages);
+  const seen = new Set<string>();
+
+  return audit.metaTags.flatMap((meta) => {
+    if (!meta.noindex) return [];
+
+    const absoluteUrl = toAbsolutePageUrl(meta.page, domain);
+    const key = normalizePageKey(absoluteUrl);
+    if (seen.has(key)) return [];
+
+    const scPage = scByPage.get(key);
+    if (!scPage || scPage.clicks <= 0) return [];
+    seen.add(key);
+
+    return [{
+      page: scPage.page || absoluteUrl,
+      clicks: scPage.clicks,
+      impressions: scPage.impressions,
+    }];
+  });
 }
 
 function getLowEngagementPages(
@@ -246,6 +289,23 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site, signals: Sit
       severity: 'medium',
       category: 'structured-data',
       hint: 'Add <script type="application/ld+json"> blocks with schema.org types appropriate for your content: Product for items with prices, WebApplication for the homepage, BreadcrumbList for navigation hierarchy.',
+    });
+  }
+
+  const noindexButRankingPages = signals.scTopPages
+    ? getNoindexButRankingPages(audit, signals.scTopPages, site.domain)
+    : [];
+  if (noindexButRankingPages.length > 0) {
+    const worstConflict = noindexButRankingPages.reduce((best, page) => page.clicks > best.clicks ? page : best, noindexButRankingPages[0]);
+    gaps.push({
+      id: 'noindex-but-ranking',
+      title: 'Remove accidental noindex from ranking pages',
+      description: `${noindexButRankingPages.length} noindexed page${noindexButRankingPages.length === 1 ? '' : 's'} still receive Search Console clicks. The highest-risk conflict is ${worstConflict.page} with ${worstConflict.clicks} click${worstConflict.clicks === 1 ? '' : 's'}.`,
+      severity: 'high',
+      category: 'indexing',
+      hint: 'Confirm whether each page should be excluded from search. If the page should rank, remove the noindex directive from the rendered HTML or X-Robots-Tag response header and request re-indexing. If the noindex is intentional, redirect or de-optimize the page so it stops attracting search traffic first.',
+      affectedPages: noindexButRankingPages.map((page) => page.page),
+      evidence: noindexButRankingPages.map((page) => `${page.page} · ${page.clicks} click${page.clicks === 1 ? '' : 's'} · ${page.impressions} impressions`),
     });
   }
 
@@ -441,6 +501,7 @@ const GAP_SECTION_MAP: Record<string, string> = {
   'missing-canonical': 'metaTags',
   'broken-canonical-targets': 'metaTags',
   'missing-twitter-card': 'metaTags',
+  'noindex-but-ranking': 'indexing',
   'missing-og-image': 'ogImage',
   'missing-json-ld': 'metaTags',
   'missing-image-alt': 'imageSeo',


### PR DESCRIPTION
Closes #86

Picked trusted issue `#86`, validated it against current `HEAD`, created the TamTam issue branch, implemented the noindex-vs-ranking detection flow, and updated agent memory.

---
Implemented via TamTam from issue [#86](https://github.com/3h4x/seo-tools/issues/86).