### PR TITLE
fix: Track indexing coverage trends so sitemap-vs-index drift stays visible

### DIFF
--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -228,6 +228,17 @@ function OverviewTab({
                   />
                 </div>
               )}
+              {auditTrends.some((row) => row.coveragePct !== undefined) && (
+                <div>
+                  <h3 className="text-neutral-500 text-xs uppercase tracking-wider mb-3 font-semibold">Indexing Coverage · % of sitemap URLs appearing in search</h3>
+                  <TrendChart
+                    data={auditTrends}
+                    lines={[{ key: 'coveragePct', color: '#38bdf8', label: 'Coverage %' }]}
+                    height={160}
+                    valueFormat="integer"
+                  />
+                </div>
+              )}
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
                 {ga4Trends.length > 0 && (
                   <TrendsTable
@@ -291,6 +302,23 @@ function OverviewTab({
                       <span key="p" className="text-emerald-400">{row.pass}</span>,
                       <span key="w" className="text-amber-400">{row.warn}</span>,
                       <span key="f" className="text-red-400">{row.fail}</span>,
+                    ])}
+                  />
+                )}
+                {auditTrends.some((row) => row.coveragePct !== undefined) && (
+                  <TrendsTable
+                    title="Indexing Coverage"
+                    columns={[
+                      { label: 'Date' },
+                      { label: 'Coverage', align: 'right' },
+                      { label: 'Indexed', align: 'right' },
+                      { label: 'Sitemap URLs', align: 'right' },
+                    ]}
+                    rows={auditTrends.map((row) => [
+                      <span key="d" className="text-neutral-400">{row.date}</span>,
+                      <span key="c" className="text-sky-400">{row.coveragePct !== undefined ? `${row.coveragePct}%` : '—'}</span>,
+                      <span key="i" className="text-neutral-400">{row.indexedPages?.toLocaleString() ?? '—'}</span>,
+                      <span key="s" className="text-neutral-400">{row.sitemapUrls?.toLocaleString() ?? '—'}</span>,
                     ])}
                   />
                 )}

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -52,6 +52,7 @@ import {
   getGa4DailyOperationalStatus,
   getSitemapSyncOperationalStatus,
   getSnapshotOperationalStatus,
+  getAuditTrends,
 } from '../db';
 
 /** Wipe volatile tables between tests so state never leaks. */
@@ -253,6 +254,37 @@ describe('dbDeleteSite', () => {
     expect(db.prepare('SELECT 1 AS present FROM sites WHERE id = ?').get('site-a')).toBeUndefined();
     expect(db.prepare('SELECT 1 AS present FROM sites WHERE id = ?').get('site-b')).toEqual({ present: 1 });
     expect(db.prepare('SELECT 1 AS present FROM api_cache WHERE site_id = ?').get('site-b')).toEqual({ present: 1 });
+  });
+});
+
+describe('trend helpers', () => {
+  it('hides stored indexing coverage when the site skips indexing checks', () => {
+    const db = getDb();
+    dbUpsertSite({
+      id: 'site-a',
+      name: 'Site A',
+      domain: 'a.example',
+      testPages: ['/'],
+      skipChecks: ['indexing'],
+    });
+    db.prepare(`
+      INSERT INTO audit_snapshots (
+        site_id, date, pass_count, warn_count, fail_count, checks_json,
+        sitemap_urls, indexed_pages, coverage_pct
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run('site-a', '2026-05-10', 1, 2, 3, '{}', 10, 8, 80);
+
+    expect(getAuditTrends('site-a')).toEqual([
+      {
+        date: '2026-05-10',
+        pass: 1,
+        warn: 2,
+        fail: 3,
+        sitemapUrls: undefined,
+        indexedPages: undefined,
+        coveragePct: undefined,
+      },
+    ]);
   });
 });
 

--- a/src/lib/__tests__/snapshot.test.ts
+++ b/src/lib/__tests__/snapshot.test.ts
@@ -17,8 +17,8 @@ vi.mock('../google-auth', () => ({
 }));
 
 const mockSites = vi.hoisted(() => [
-  { id: 'site-a', domain: 'a.example.com', ga4PropertyId: '111', searchConsole: true },
-  { id: 'site-b', domain: 'b.example.com', ga4PropertyId: '222', searchConsole: true },
+  { id: 'site-a', domain: 'a.example.com', ga4PropertyId: '111', searchConsole: true, skipChecks: [] as string[] },
+  { id: 'site-b', domain: 'b.example.com', ga4PropertyId: '222', searchConsole: true, skipChecks: [] as string[] },
 ]);
 
 vi.mock('../ga4', () => ({
@@ -29,7 +29,12 @@ vi.mock('../sites', () => ({
   getSCUrl: (s: { domain: string }) => `sc-domain:${s.domain}`,
 }));
 
-const scQueryMock = vi.fn();
+const runSiteAuditMock = vi.hoisted(() => vi.fn());
+vi.mock('../audit', () => ({
+  runSiteAudit: runSiteAuditMock,
+}));
+
+const scQueryMock = vi.hoisted(() => vi.fn());
 vi.mock('@googleapis/searchconsole', () => ({
   searchconsole_v1: {
     Searchconsole: function () {
@@ -38,7 +43,7 @@ vi.mock('@googleapis/searchconsole', () => ({
   },
 }));
 
-const ga4ReportMock = vi.fn();
+const ga4ReportMock = vi.hoisted(() => vi.fn());
 vi.mock('@google-analytics/data', () => ({
   BetaAnalyticsDataClient: function () {
     return { runReport: ga4ReportMock };
@@ -65,7 +70,31 @@ function resetDb() {
 beforeEach(() => {
   resetDb();
   vi.clearAllMocks();
+  mockSites[0].skipChecks = [];
+  mockSites[1].skipChecks = [];
   fetchMock.mockResolvedValue({ ok: true, status: 200 });
+  runSiteAuditMock.mockImplementation(async (site: { id: string; domain: string }) => ({
+    siteId: site.id,
+    domain: site.domain,
+    timestamp: Date.now(),
+    robotsTxt: { status: 'pass', label: 'robots.txt', message: 'OK', hasSitemapDirective: true },
+    sitemap: { status: 'pass', label: 'Sitemap', message: 'OK', urlCount: 12 },
+    scSitemapFreshness: { status: 'pass', label: 'SC Sitemap', message: 'OK' },
+    indexingCoverage: { status: 'warn', label: 'Indexing', message: 'Coverage', sitemapUrls: 12, indexedPages: 9, coveragePct: 75 },
+    redirectChains: [],
+    metaTags: [],
+    ogImage: { status: 'pass', label: 'OG Image', message: 'OK' },
+    ttfb: { status: 'pass', label: 'TTFB', message: 'Fast', ms: site.id === 'site-a' ? 320 : 450 },
+    imageSeo: [],
+    internalLinks: [],
+    security: {
+      https: { status: 'pass', label: 'HTTPS', message: 'OK' },
+      hsts: { status: 'pass', label: 'HSTS', message: 'OK' },
+      favicon: { status: 'pass', label: 'Favicon', message: 'OK' },
+    },
+    score: { pass: 7, warn: 1, fail: 0, error: 0, total: 8 },
+    sampledPages: ['/'],
+  }));
 
   // SC returns a page-dimension query and a query-dimension query in order per site.
   scQueryMock.mockImplementation(async ({ requestBody }: { requestBody: { dimensions: string[] } }) => {
@@ -116,19 +145,64 @@ describe('runSnapshot dedupe', () => {
 });
 
 describe('runSnapshot TTFB', () => {
-  it('writes ttfb_ms to audit_snapshots for each site', async () => {
+  it('writes audit-derived indexing coverage and ttfb to audit_snapshots for each site', async () => {
     const result = await runSnapshot();
     expect(result.ttfb).toBe(2);
 
     const db = getDb();
     const rows = db.prepare(
-      'SELECT site_id, ttfb_ms FROM audit_snapshots WHERE date = ? ORDER BY site_id',
-    ).all(result.date) as Array<{ site_id: string; ttfb_ms: number }>;
+      'SELECT site_id, ttfb_ms, sitemap_urls, indexed_pages, coverage_pct, pass_count, warn_count, fail_count FROM audit_snapshots WHERE date = ? ORDER BY site_id',
+    ).all(result.date) as Array<{
+      site_id: string;
+      ttfb_ms: number;
+      sitemap_urls: number;
+      indexed_pages: number;
+      coverage_pct: number;
+      pass_count: number;
+      warn_count: number;
+      fail_count: number;
+    }>;
 
     expect(rows).toHaveLength(2);
     expect(rows[0].site_id).toBe('site-a');
-    expect(rows[0].ttfb_ms).toBeGreaterThanOrEqual(0);
+    expect(rows[0].ttfb_ms).toBe(320);
+    expect(rows[0].sitemap_urls).toBe(12);
+    expect(rows[0].indexed_pages).toBe(9);
+    expect(rows[0].coverage_pct).toBe(75);
+    expect(rows[0].pass_count).toBe(7);
+    expect(rows[0].warn_count).toBe(1);
+    expect(rows[0].fail_count).toBe(0);
     expect(rows[1].site_id).toBe('site-b');
+  });
+
+  it('stores null indexing coverage when the site skips indexing checks', async () => {
+    mockSites[0].skipChecks = ['indexing'];
+
+    const result = await runSnapshot();
+
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT site_id, sitemap_urls, indexed_pages, coverage_pct FROM audit_snapshots WHERE date = ? ORDER BY site_id',
+    ).all(result.date) as Array<{
+      site_id: string;
+      sitemap_urls: number | null;
+      indexed_pages: number | null;
+      coverage_pct: number | null;
+    }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      site_id: 'site-a',
+      sitemap_urls: null,
+      indexed_pages: null,
+      coverage_pct: null,
+    });
+    expect(rows[1]).toEqual({
+      site_id: 'site-b',
+      sitemap_urls: 12,
+      indexed_pages: 9,
+      coverage_pct: 75,
+    });
   });
 
   it('deduplicates audit_snapshots on re-run', async () => {
@@ -152,9 +226,9 @@ describe('runSnapshot TTFB', () => {
   });
 
   it('records TTFB fetch error and continues other sites', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    runSiteAuditMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
     const result = await runSnapshot();
-    expect(result.errors.some((e) => e.includes('TTFB site-a'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('Audit site-a'))).toBe(true);
     expect(result.ttfb).toBe(1); // site-b still succeeds
   });
 });

--- a/src/lib/__tests__/trends-page.test.tsx
+++ b/src/lib/__tests__/trends-page.test.tsx
@@ -314,7 +314,7 @@ beforeEach(() => {
     { date: '2026-05-02', users: 25, sessions: 35, views: 45, bounceRate: 0.35, avgDuration: 18 },
   ]);
   mockGetAuditTrends.mockReturnValue([
-    { date: '2026-05-02', pass: 7, warn: 1, fail: 0 },
+    { date: '2026-05-02', pass: 7, warn: 1, fail: 0, sitemapUrls: 10, indexedPages: 8, coveragePct: 80 },
   ]);
   mockGetTtfbTrends.mockReturnValue([]);
   mockGetTopKeywordsWithHistory.mockReturnValue({
@@ -377,6 +377,29 @@ describe('TrendsPage', () => {
       }),
       undefined
     );
+    expect(mockTrendsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Indexing Coverage',
+        columns: expect.arrayContaining([
+          expect.objectContaining({ label: 'Coverage', align: 'right' }),
+          expect.objectContaining({ label: 'Sitemap URLs', align: 'right' }),
+        ]),
+      }),
+      undefined
+    );
+  });
+
+  it('does not render indexing coverage trends when coverage fields are unavailable', async () => {
+    mockGetAuditTrends.mockReturnValue([
+      { date: '2026-05-02', pass: 7, warn: 1, fail: 0 },
+    ]);
+
+    const html = renderToStaticMarkup(await TrendsPage({
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(html).not.toContain('Indexing Coverage');
+    expect(mockTrendsTable.mock.calls.some(([props]) => props.title === 'Indexing Coverage')).toBe(false);
   });
 
   it('renders the keyword section first for legacy tab=keywords links', async () => {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1490,6 +1490,10 @@ async function auditSite(site: Site): Promise<SiteAuditResult> {
   };
 }
 
+export async function runSiteAudit(site: Site): Promise<SiteAuditResult> {
+  return auditSite(site);
+}
+
 async function auditAllSites(): Promise<SiteAuditResult[]> {
   const sites = await getManagedSites();
   return Promise.all(sites.map(site => auditSite(site)));
@@ -1500,7 +1504,7 @@ async function auditAllSites(): Promise<SiteAuditResult[]> {
 import { withCache, CACHE_TTL_WEEK } from './db';
 
 export async function cachedAuditSite(site: Site): Promise<SiteAuditResult> {
-  const audit = (await withCache<SiteAuditResult>('audit', site.id, () => auditSite(site), CACHE_TTL_WEEK))!;
+  const audit = (await withCache<SiteAuditResult>('audit', site.id, () => runSiteAudit(site), CACHE_TTL_WEEK))!;
   return normalizeSiteAuditResult(audit);
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { computeKeywordDeltas, type KeywordDelta } from './keyword-history';
 import { openDatabase } from './sqlite-driver.js';
+import { normalizeSkipChecks } from './skip-checks';
 
 const DB_PATH = path.join(process.cwd(), 'data', 'seo-tools.db');
 
@@ -68,6 +69,9 @@ function initSchema(db: SqliteDatabase): void {
       warn_count INTEGER NOT NULL DEFAULT 0,
       fail_count INTEGER NOT NULL DEFAULT 0,
       checks_json TEXT NOT NULL DEFAULT '{}',
+      sitemap_urls INTEGER,
+      indexed_pages INTEGER,
+      coverage_pct INTEGER,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -163,6 +167,9 @@ function initSchema(db: SqliteDatabase): void {
   // Migrations for existing DBs
   try { db.exec(`ALTER TABLE sites ADD COLUMN color TEXT`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN ttfb_ms INTEGER`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN sitemap_urls INTEGER`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN indexed_pages INTEGER`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN coverage_pct INTEGER`); } catch { /* already exists */ }
 }
 
 // --- Cache helpers ---
@@ -276,6 +283,9 @@ interface AuditTrendPoint {
   pass: number;
   warn: number;
   fail: number;
+  sitemapUrls?: number;
+  indexedPages?: number;
+  coveragePct?: number;
 }
 
 export function getScTrends(siteId: string, limit: number = 90): ScTrendPoint[] {
@@ -317,17 +327,43 @@ export function getGa4Trends(siteId: string, limit: number = 90): Ga4TrendPoint[
 export function getAuditTrends(siteId: string, limit: number = 90): AuditTrendPoint[] {
   const db = getDb();
   const rows = db.prepare(`
-    SELECT date, pass_count, warn_count, fail_count
-    FROM audit_snapshots WHERE site_id = ?
-    ORDER BY date DESC LIMIT ?
-  `).all(siteId, limit) as Array<{ date: string; pass_count: number; warn_count: number; fail_count: number }>;
+    SELECT a.date, a.pass_count, a.warn_count, a.fail_count, a.sitemap_urls, a.indexed_pages, a.coverage_pct,
+           s.skip_checks
+    FROM audit_snapshots a
+    LEFT JOIN sites s ON s.id = a.site_id
+    WHERE a.site_id = ?
+    ORDER BY a.date DESC LIMIT ?
+  `).all(siteId, limit) as Array<{
+    date: string;
+    pass_count: number;
+    warn_count: number;
+    fail_count: number;
+    sitemap_urls: number | null;
+    indexed_pages: number | null;
+    coverage_pct: number | null;
+    skip_checks: string | null;
+  }>;
 
-  return rows.reverse().map(r => ({
-    date: r.date,
-    pass: r.pass_count,
-    warn: r.warn_count,
-    fail: r.fail_count,
-  }));
+  return rows.reverse().map(r => {
+    const skipChecks = (() => {
+      try {
+        return normalizeSkipChecks(JSON.parse(r.skip_checks ?? '[]') as string[]);
+      } catch {
+        return [];
+      }
+    })();
+    const isIndexingSkipped = skipChecks.includes('indexing');
+
+    return {
+      date: r.date,
+      pass: r.pass_count,
+      warn: r.warn_count,
+      fail: r.fail_count,
+      sitemapUrls: isIndexingSkipped ? undefined : r.sitemap_urls ?? undefined,
+      indexedPages: isIndexingSkipped ? undefined : r.indexed_pages ?? undefined,
+      coveragePct: isIndexingSkipped ? undefined : r.coverage_pct ?? undefined,
+    };
+  });
 }
 
 export interface TtfbTrendPoint {

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -4,6 +4,8 @@ import { getAuth } from './google-auth';
 import { getDb } from './db';
 import { discoverPropertyIds } from './ga4';
 import { getSCUrl } from './sites';
+import { runSiteAudit } from './audit';
+import { normalizeSkipChecks } from './skip-checks';
 
 export interface SnapshotResult {
   date: string;
@@ -157,24 +159,41 @@ async function doSnapshot(): Promise<SnapshotResult> {
 
   const auditDelete = db.prepare('DELETE FROM audit_snapshots WHERE site_id = ? AND date = ?');
   const auditInsert = db.prepare(
-    'INSERT INTO audit_snapshots (site_id, date, pass_count, warn_count, fail_count, checks_json, ttfb_ms) VALUES (?, ?, 0, 0, 0, ?, ?)',
+    `INSERT INTO audit_snapshots (
+      site_id, date, pass_count, warn_count, fail_count, checks_json, ttfb_ms,
+      sitemap_urls, indexed_pages, coverage_pct
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   let ttfbCount = 0;
   for (const site of sites) {
     try {
-      const start = Date.now();
-      await fetch(`https://${site.domain}/`, {
-        signal: AbortSignal.timeout(10_000),
-        method: 'HEAD',
-      });
-      const ttfbMs = Date.now() - start;
+      const audit = await runSiteAudit(site);
+      const ttfbMs = audit.ttfb.ms;
+      const skipChecks = normalizeSkipChecks(site.skipChecks);
+      const shouldStoreIndexingCoverage = !skipChecks.includes('indexing');
+      const { sitemapUrls, indexedPages, coveragePct } = shouldStoreIndexingCoverage
+        ? audit.indexingCoverage
+        : { sitemapUrls: null, indexedPages: null, coveragePct: null };
       db.transaction(() => {
         auditDelete.run(site.id, today);
-        auditInsert.run(site.id, today, '{}', ttfbMs);
+        auditInsert.run(
+          site.id,
+          today,
+          audit.score.pass,
+          audit.score.warn,
+          audit.score.fail,
+          JSON.stringify(audit),
+          ttfbMs ?? null,
+          sitemapUrls ?? null,
+          indexedPages ?? null,
+          coveragePct ?? null,
+        );
       })();
-      ttfbCount++;
+      if (typeof ttfbMs === 'number') {
+        ttfbCount++;
+      }
     } catch (e) {
-      errors.push(`TTFB ${site.id}: ${String(e).slice(0, 80)}`);
+      errors.push(`Audit ${site.id}: ${String(e).slice(0, 80)}`);
     }
   }
 


### PR DESCRIPTION
Closes #14

Implemented issue `#14` by wiring audit-derived indexing coverage into snapshot storage and the `/trends` UI, and updated agent memory.

---
Implemented via TamTam from issue [#14](https://github.com/3h4x/seo-tools/issues/14).