### PR TITLE
fix: Validate JSON-LD schema markup via Rich Results API so invalid structured data surfaces before Google flags it

### DIFF
--- a/app/audit/page.tsx
+++ b/app/audit/page.tsx
@@ -43,7 +43,7 @@ function metaTagsSummary(audit: SiteAuditResult): { status: CheckStatus; label: 
   const pages = audit.metaTags;
   const issues = pages.filter(p => {
     const checks = [p.title, p.description, p.ogTitle, p.ogImage, p.ogDescription, p.twitterCard, p.canonical, p.jsonLd];
-    return checks.some(c => c.status === 'fail' || c.status === 'error');
+    return checks.some(c => c.status === 'fail' || c.status === 'error' || (c.label === 'JSON-LD' && c.status === 'warn'));
   });
   if (issues.length === 0) return { status: 'pass', label: `${pages.length}/${pages.length} pages pass` };
   if (issues.length === pages.length) return { status: 'fail', label: `${issues.length}/${pages.length} have issues` };

--- a/app/components/audit/check-card.tsx
+++ b/app/components/audit/check-card.tsx
@@ -66,12 +66,19 @@ export function MetaChecksTable({ checks }: { checks: CheckResult[] }) {
   return (
     <div className="space-y-1">
       {checks.map((c, i) => (
-        <div key={i} className="flex items-center gap-3 text-xs py-1">
-          <div className={`size-1.5 rounded-full shrink-0 ${statusDots[c.status]}`} />
-          <span className="text-neutral-500 w-28 shrink-0">{c.label}</span>
-          <span className={`font-mono truncate ${c.status === 'fail' ? 'text-red-400' : 'text-neutral-300'}`}>
-            {c.message}
-          </span>
+        <div key={i} className="py-1">
+          <div className="flex items-center gap-3 text-xs">
+            <div className={`size-1.5 rounded-full shrink-0 ${statusDots[c.status]}`} />
+            <span className="text-neutral-500 w-28 shrink-0">{c.label}</span>
+            <span className={`font-mono truncate ${c.status === 'fail' ? 'text-red-400' : c.status === 'warn' ? 'text-amber-400' : 'text-neutral-300'}`}>
+              {c.message}
+            </span>
+          </div>
+          {c.details && (
+            <pre className="ml-[calc(0.375rem+0.75rem+7rem)] mt-1 whitespace-pre-wrap break-words text-[11px] text-neutral-500 font-mono">
+              {c.details}
+            </pre>
+          )}
         </div>
       ))}
     </div>

--- a/src/lib/__tests__/audit-helpers.test.ts
+++ b/src/lib/__tests__/audit-helpers.test.ts
@@ -123,7 +123,7 @@ describe('parseMetaTags', () => {
       <meta property="og:description" content="OG description text here.">
       <meta name="twitter:card" content="summary_large_image">
       <link rel="canonical" href="https://example.com/">
-      <script type="application/ld+json">{"@type":"Product","name":"Example"}</script>
+      <script type="application/ld+json">{"@type":"Product","name":"Example","brand":{"@type":"Brand","name":"Example"}}</script>
     </head>
     </html>
   `;
@@ -175,6 +175,68 @@ describe('parseMetaTags', () => {
     const res = makeFetchResult({ text: fullHtml });
     const result = parseMetaTags(res, '/');
     expect(result.jsonLd.message).toContain('Product');
+  });
+
+  it('fails JSON-LD when structured data contains invalid JSON', () => {
+    const html = `
+      <html>
+      <head>
+        <title>Test</title>
+        <script type="application/ld+json">{"@type":"Product",}</script>
+      </head>
+      </html>
+    `;
+    const res = makeFetchResult({ text: html });
+    const result = parseMetaTags(res, '/');
+    expect(result.jsonLd.status).toBe('fail');
+    expect(result.jsonLd.message).toBe('Invalid JSON in structured data');
+  });
+
+  it('warns when Product schema is missing required fields', () => {
+    const html = `
+      <html>
+      <head>
+        <title>Test</title>
+        <script type="application/ld+json">{"@type":"Product","name":"Example"}</script>
+      </head>
+      </html>
+    `;
+    const res = makeFetchResult({ text: html });
+    const result = parseMetaTags(res, '/');
+    expect(result.jsonLd.status).toBe('warn');
+    expect(result.jsonLd.message).toContain('Product missing one of "offers", "brand", or "image"');
+  });
+
+  it('warns when BreadcrumbList entries are incomplete', () => {
+    const html = `
+      <html>
+      <head>
+        <title>Test</title>
+        <script type="application/ld+json">{"@type":"BreadcrumbList","itemListElement":[{"position":1}]}</script>
+      </head>
+      </html>
+    `;
+    const res = makeFetchResult({ text: html });
+    const result = parseMetaTags(res, '/');
+    expect(result.jsonLd.status).toBe('warn');
+    expect(result.jsonLd.details).toContain('BreadcrumbList missing "itemListElement.item"');
+  });
+
+  it('passes multiple valid JSON-LD blocks and lists discovered schema types', () => {
+    const html = `
+      <html>
+      <head>
+        <title>Test</title>
+        <script type="application/ld+json">{"@type":"WebApplication","name":"Example","applicationCategory":"BusinessApplication"}</script>
+        <script type="application/ld+json">{"@type":"BreadcrumbList","itemListElement":[{"item":"https://example.com/","position":1}]}</script>
+      </head>
+      </html>
+    `;
+    const res = makeFetchResult({ text: html });
+    const result = parseMetaTags(res, '/');
+    expect(result.jsonLd.status).toBe('pass');
+    expect(result.jsonLd.message).toContain('WebApplication');
+    expect(result.jsonLd.message).toContain('BreadcrumbList');
   });
 
   it('extracts ogImageUrl for OG image check chaining', () => {

--- a/src/lib/__tests__/gaps.test.ts
+++ b/src/lib/__tests__/gaps.test.ts
@@ -399,6 +399,44 @@ describe('analyzeSiteGaps', () => {
     expect(result.gaps.find(g => g.id === 'missing-json-ld')).toBeUndefined();
   });
 
+  it('includes missing-json-ld-fields when structured data is invalid or incomplete', () => {
+    const audit = makeAudit({
+      metaTags: [
+        makeMetaTagResult('/', {
+          jsonLd: {
+            ...makeCheckResult('warn', 'JSON-LD'),
+            message: 'Product missing one of "offers", "brand", or "image"',
+          },
+        }),
+      ],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    const gap = result.gaps.find((candidate) => candidate.id === 'missing-json-ld-fields');
+    expect(gap).toBeDefined();
+    expect(gap?.severity).toBe('medium');
+    expect(gap?.affectedPages).toEqual(['/']);
+    expect(gap?.evidence).toEqual(['/ · Product missing one of "offers", "brand", or "image"']);
+    expect(result.gaps.find((candidate) => candidate.id === 'missing-json-ld')).toBeUndefined();
+  });
+
+  it('treats malformed JSON-LD as invalid fields work, not missing JSON-LD', () => {
+    const audit = makeAudit({
+      metaTags: [
+        makeMetaTagResult('/', {
+          jsonLd: {
+            ...makeCheckResult('fail', 'JSON-LD'),
+            message: 'Invalid JSON in structured data',
+          },
+        }),
+      ],
+    });
+    const result = analyzeSiteGaps(audit, makeSite());
+    const gap = result.gaps.find((candidate) => candidate.id === 'missing-json-ld-fields');
+    expect(gap).toBeDefined();
+    expect(gap?.severity).toBe('high');
+    expect(result.gaps.find((candidate) => candidate.id === 'missing-json-ld')).toBeUndefined();
+  });
+
   it('includes missing-canonical gap for pages without canonical', () => {
     const audit = makeAudit({
       metaTags: [makeMetaTagResult('/', { canonical: makeCheckResult('fail', 'canonical') })],

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -605,6 +605,20 @@ export function makeCheck(label: string, value: string | null, minLen: number = 
 
 const GENERIC_TITLES = ['react app', 'vite app', 'document', 'untitled', 'home', 'index'];
 
+interface JsonLdValidationResult {
+  status: CheckStatus;
+  message: string;
+  details?: string;
+}
+
+type JsonLdSchemaType = 'WebApplication' | 'Product' | 'BreadcrumbList';
+
+const JSON_LD_SCHEMA_LABELS: Record<JsonLdSchemaType, string> = {
+  WebApplication: 'WebApplication',
+  Product: 'Product',
+  BreadcrumbList: 'BreadcrumbList',
+};
+
 function hasNoindexDirective(value: string | null | undefined): boolean {
   return value ? /\b(?:noindex|none)\b/i.test(value) : false;
 }
@@ -634,6 +648,141 @@ function xRobotsTagHasApplicableNoindex(value: string | null | undefined): boole
   }
 
   return false;
+}
+
+function extractJsonLdBlocks(html: string): string[] {
+  return [...html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)]
+    .map((match) => match[1]?.trim() ?? '')
+    .filter(Boolean);
+}
+
+function getJsonLdTypes(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  }
+  return [];
+}
+
+function collectJsonLdEntries(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectJsonLdEntries(entry));
+  }
+
+  if (!value || typeof value !== 'object') return [];
+
+  const entry = value as Record<string, unknown>;
+  const graphEntries = Array.isArray(entry['@graph']) ? collectJsonLdEntries(entry['@graph']) : [];
+  return [entry, ...graphEntries];
+}
+
+function validateJsonLdEntry(entry: Record<string, unknown>): string[] {
+  const types = getJsonLdTypes(entry['@type']);
+  if (types.length === 0) return [];
+
+  const issues = new Set<string>();
+
+  for (const type of types) {
+    if (type === 'WebApplication') {
+      if (typeof entry.name !== 'string' || entry.name.trim().length === 0) {
+        issues.add(`${JSON_LD_SCHEMA_LABELS.WebApplication} missing "name"`);
+      }
+      if (typeof entry.applicationCategory !== 'string' || entry.applicationCategory.trim().length === 0) {
+        issues.add(`${JSON_LD_SCHEMA_LABELS.WebApplication} missing "applicationCategory"`);
+      }
+    }
+
+    if (type === 'Product') {
+      if (typeof entry.name !== 'string' || entry.name.trim().length === 0) {
+        issues.add(`${JSON_LD_SCHEMA_LABELS.Product} missing "name"`);
+      }
+      if (!entry.offers && !entry.brand && !entry.image) {
+        issues.add(`${JSON_LD_SCHEMA_LABELS.Product} missing one of "offers", "brand", or "image"`);
+      }
+    }
+
+    if (type === 'BreadcrumbList') {
+      const itemListElement = entry.itemListElement;
+      if (!Array.isArray(itemListElement) || itemListElement.length === 0) {
+        issues.add(`${JSON_LD_SCHEMA_LABELS.BreadcrumbList} missing "itemListElement"`);
+        continue;
+      }
+
+      for (const item of itemListElement) {
+        if (!item || typeof item !== 'object') {
+          issues.add(`${JSON_LD_SCHEMA_LABELS.BreadcrumbList} itemListElement entries must include "item" and "position"`);
+          break;
+        }
+
+        const listItem = item as Record<string, unknown>;
+        if (!('item' in listItem)) {
+          issues.add(`${JSON_LD_SCHEMA_LABELS.BreadcrumbList} missing "itemListElement.item"`);
+        }
+        if (!('position' in listItem)) {
+          issues.add(`${JSON_LD_SCHEMA_LABELS.BreadcrumbList} missing "itemListElement.position"`);
+        }
+      }
+    }
+  }
+
+  return [...issues];
+}
+
+function validateJsonLd(html: string): JsonLdValidationResult {
+  const blocks = extractJsonLdBlocks(html);
+  if (blocks.length === 0) {
+    return { status: 'fail', message: 'Not found' };
+  }
+
+  const parseErrors: string[] = [];
+  const validationIssues = new Set<string>();
+  const discoveredTypes = new Set<string>();
+
+  for (const block of blocks) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block);
+    } catch {
+      parseErrors.push('Invalid JSON in structured data');
+      continue;
+    }
+
+    for (const entry of collectJsonLdEntries(parsed)) {
+      for (const type of getJsonLdTypes(entry['@type'])) {
+        discoveredTypes.add(type);
+      }
+
+      for (const issue of validateJsonLdEntry(entry)) {
+        validationIssues.add(issue);
+      }
+    }
+  }
+
+  if (parseErrors.length > 0) {
+    return {
+      status: 'fail',
+      message: 'Invalid JSON in structured data',
+      details: parseErrors.join('\n'),
+    };
+  }
+
+  if (validationIssues.size > 0) {
+    const issueList = [...validationIssues];
+    return {
+      status: 'warn',
+      message: issueList[0],
+      details: issueList.join('\n'),
+    };
+  }
+
+  const typeLabel = discoveredTypes.size > 0
+    ? `Valid (${[...discoveredTypes].join(', ')})`
+    : 'Valid';
+
+  return {
+    status: 'pass',
+    message: typeLabel,
+  };
 }
 
 export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
@@ -675,15 +824,7 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
   const canonicalMatch = html.match(/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']*?)["'][^>]*>/i);
   const canonical = canonicalMatch?.[1] ?? null;
 
-  const hasJsonLd = /<script[^>]+type=["']application\/ld\+json["'][^>]*>/i.test(html);
-  let jsonLdType: string | undefined;
-  if (hasJsonLd) {
-    const jsonLdMatch = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i);
-    try {
-      const parsed = JSON.parse(jsonLdMatch?.[1] || '{}');
-      jsonLdType = parsed['@type'] || (Array.isArray(parsed) ? parsed[0]?.['@type'] : undefined);
-    } catch { /* ignore parse errors */ }
-  }
+  const jsonLd = validateJsonLd(html);
 
   return {
     page,
@@ -699,9 +840,7 @@ export function parseMetaTags(res: FetchResult, page: string): MetaTagResult {
     ogDescription: makeCheck('og:description', ogDesc, 10),
     twitterCard: makeCheck('twitter:card', twitterCard),
     canonical: makeCheck('canonical', canonical),
-    jsonLd: hasJsonLd
-      ? { status: 'pass', label: 'JSON-LD', message: jsonLdType ? `Found (${jsonLdType})` : 'Found' }
-      : { status: 'fail', label: 'JSON-LD', message: 'Not found' },
+    jsonLd: { status: jsonLd.status, label: 'JSON-LD', message: jsonLd.message, details: jsonLd.details },
   };
 }
 

--- a/src/lib/gaps.ts
+++ b/src/lib/gaps.ts
@@ -43,6 +43,8 @@ interface SiteGapAnalysis {
   counts: { high: number; medium: number; low: number };
 }
 
+const JSON_LD_INVALID_JSON_MESSAGE = 'Invalid JSON in structured data';
+
 export interface SiteGapSignals {
   ga4TopPages?: GA4TopPage[];
   scTopPages?: SCPageRow[];
@@ -90,6 +92,15 @@ function normalizePageKey(value: string): string {
     const normalized = trimmed.replace(/\/+$/, '') || '/';
     return normalized;
   }
+}
+
+function isMissingJsonLd(meta: SiteAuditResult['metaTags'][number]): boolean {
+  return meta.jsonLd.status === 'fail' && meta.jsonLd.message !== JSON_LD_INVALID_JSON_MESSAGE;
+}
+
+function isInvalidJsonLd(meta: SiteAuditResult['metaTags'][number]): boolean {
+  return meta.jsonLd.status === 'warn'
+    || (meta.jsonLd.status === 'fail' && meta.jsonLd.message === JSON_LD_INVALID_JSON_MESSAGE);
 }
 
 interface AggregatedScPageSignal {
@@ -280,7 +291,8 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site, signals: Sit
   }
 
   // MEDIUM: JSON-LD missing on all pages
-  const allJsonLdFail = audit.metaTags.every((m) => m.jsonLd.status === 'fail');
+  const allJsonLdFail = audit.metaTags.length > 0
+    && audit.metaTags.every(isMissingJsonLd);
   if (allJsonLdFail) {
     gaps.push({
       id: 'missing-json-ld',
@@ -289,6 +301,20 @@ export function analyzeSiteGaps(audit: SiteAuditResult, site: Site, signals: Sit
       severity: 'medium',
       category: 'structured-data',
       hint: 'Add <script type="application/ld+json"> blocks with schema.org types appropriate for your content: Product for items with prices, WebApplication for the homepage, BreadcrumbList for navigation hierarchy.',
+    });
+  }
+
+  const invalidJsonLdPages = audit.metaTags.filter(isInvalidJsonLd);
+  if (invalidJsonLdPages.length > 0) {
+    gaps.push({
+      id: 'missing-json-ld-fields',
+      title: 'Fix invalid or incomplete structured data',
+      description: 'Some pages include JSON-LD, but required schema fields are missing or the JSON is malformed. Search engines can ignore these blocks entirely, preventing rich results.',
+      severity: invalidJsonLdPages.some((meta) => meta.jsonLd.status === 'fail') ? 'high' : 'medium',
+      category: 'structured-data',
+      hint: 'Validate each JSON-LD block before deploy. Ensure Product includes name plus one of offers/brand/image, WebApplication includes name and applicationCategory, and BreadcrumbList includes itemListElement entries with item and position.',
+      affectedPages: invalidJsonLdPages.map((meta) => meta.page),
+      evidence: invalidJsonLdPages.map((meta) => `${meta.page} · ${meta.jsonLd.message}`),
     });
   }
 
@@ -504,6 +530,7 @@ const GAP_SECTION_MAP: Record<string, string> = {
   'noindex-but-ranking': 'indexing',
   'missing-og-image': 'ogImage',
   'missing-json-ld': 'metaTags',
+  'missing-json-ld-fields': 'metaTags',
   'missing-image-alt': 'imageSeo',
   'missing-lazy-loading': 'imageSeo',
   'low-internal-linking': 'internalLinks',


### PR DESCRIPTION
Closes #23

Implemented issue `#23` after validating the referenced audit and gap codepaths on current `HEAD`.

---
Implemented via TamTam from issue [#23](https://github.com/3h4x/seo-tools/issues/23).