### PR TITLE
fix: Automate snapshot scheduling so trend and history data collects without manual CLI runs

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,5 +6,8 @@ export async function register() {
 
     const { startSitemapSync } = await import('@/lib/sitemap-sync');
     startSitemapSync();
+
+    const { startSnapshotScheduler } = await import('@/lib/snapshot');
+    startSnapshotScheduler();
   }
 }

--- a/scripts/seo.mjs
+++ b/scripts/seo.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomUUID } from 'node:crypto';
 import { GoogleAuth } from 'google-auth-library';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import path from 'node:path';
@@ -22,6 +23,8 @@ if (creds.private_key) creds.private_key = creds.private_key.replace(/\\n/g, '\n
 
 const auth = new GoogleAuth({ credentials: creds, scopes: ['https://www.googleapis.com/auth/webmasters'] });
 const sc = new searchconsole_v1.Searchconsole({ auth });
+const SNAPSHOT_JOB_KEY = 'daily';
+const SNAPSHOT_STALE_LOCK_MS = 6 * 60 * 60 * 1000;
 
 function loadSites() {
   try {
@@ -150,10 +153,21 @@ async function takeSnapshot() {
     CREATE TABLE IF NOT EXISTS ga4_snapshots (id INTEGER PRIMARY KEY AUTOINCREMENT, site_id TEXT NOT NULL, date TEXT NOT NULL, users INTEGER NOT NULL DEFAULT 0, sessions INTEGER NOT NULL DEFAULT 0, views INTEGER NOT NULL DEFAULT 0, bounce_rate REAL NOT NULL DEFAULT 0, avg_duration REAL NOT NULL DEFAULT 0, created_at TEXT NOT NULL DEFAULT (datetime('now')));
     CREATE INDEX IF NOT EXISTS idx_sc_site_date ON sc_snapshots(site_id, date);
     CREATE INDEX IF NOT EXISTS idx_ga4_site_date ON ga4_snapshots(site_id, date);
+    CREATE TABLE IF NOT EXISTS snapshot_runs (
+      job_key TEXT NOT NULL PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'idle',
+      last_started_at INTEGER,
+      last_finished_at INTEGER,
+      last_success_at INTEGER,
+      last_failure_at INTEGER,
+      last_error TEXT,
+      lock_owner TEXT
+    );
     -- keyword_history is also created in src/lib/db.ts (app initSchema); keep schemas in sync
     CREATE TABLE IF NOT EXISTS keyword_history (site_id TEXT NOT NULL, date TEXT NOT NULL, query TEXT NOT NULL, clicks INTEGER NOT NULL DEFAULT 0, impressions INTEGER NOT NULL DEFAULT 0, ctr REAL NOT NULL DEFAULT 0, position REAL NOT NULL DEFAULT 0, PRIMARY KEY (site_id, date, query));
     CREATE INDEX IF NOT EXISTS idx_kw_history_site_query ON keyword_history(site_id, query, date);
   `);
+  try { db.exec(`ALTER TABLE snapshot_runs ADD COLUMN lock_owner TEXT`); } catch { /* already exists */ }
 
   const sites = loadSites();
   if (sites.length === 0) {
@@ -161,101 +175,162 @@ async function takeSnapshot() {
     return;
   }
 
-  const end = new Date(); end.setDate(end.getDate() - 1);
-  const start = new Date(); start.setDate(start.getDate() - 7);
-  const startDate = start.toISOString().split('T')[0];
-  const endDate = end.toISOString().split('T')[0];
+  const lockOwner = acquireSnapshotLock();
+  try {
+    const end = new Date(); end.setDate(end.getDate() - 1);
+    const start = new Date(); start.setDate(start.getDate() - 7);
+    const startDate = start.toISOString().split('T')[0];
+    const endDate = end.toISOString().split('T')[0];
 
-  console.log(`Taking snapshot for ${today}...\n`);
+    console.log(`Taking snapshot for ${today}...\n`);
 
-  const scDelete = db.prepare('DELETE FROM sc_snapshots WHERE site_id = ? AND date = ?');
-  const scInsert = db.prepare('INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position) VALUES (?, ?, ?, ?, ?, ?, ?)');
-  for (const site of sites) {
-    try {
-      const q = await sc.searchanalytics.query({
-        siteUrl: site.scUrl,
-        requestBody: { startDate, endDate, dimensions: ['page'], rowLimit: 100 },
-      });
-      const rows = q.data.rows || [];
-      const insertAll = db.transaction(() => {
-        scDelete.run(site.id, today);
-        for (const row of rows) {
-          scInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
-        }
-      });
-      insertAll();
-      console.log(`  SC ${site.id}: ${rows.length} pages`);
-    } catch (e) {
-      console.log(`  SC ${site.id}: error - ${e.message.slice(0, 60)}`);
+    const scDelete = db.prepare('DELETE FROM sc_snapshots WHERE site_id = ? AND date = ?');
+    const scInsert = db.prepare('INSERT INTO sc_snapshots (site_id, date, page_url, clicks, impressions, ctr, position) VALUES (?, ?, ?, ?, ?, ?, ?)');
+    for (const site of sites) {
+      try {
+        const q = await sc.searchanalytics.query({
+          siteUrl: site.scUrl,
+          requestBody: { startDate, endDate, dimensions: ['page'], rowLimit: 100 },
+        });
+        const rows = q.data.rows || [];
+        const insertAll = db.transaction(() => {
+          scDelete.run(site.id, today);
+          for (const row of rows) {
+            scInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
+          }
+        });
+        insertAll();
+        console.log(`  SC ${site.id}: ${rows.length} pages`);
+      } catch (e) {
+        console.log(`  SC ${site.id}: error - ${e.message.slice(0, 60)}`);
+      }
     }
+
+    const kwInsert = db.prepare(
+      `INSERT INTO keyword_history (site_id, date, query, clicks, impressions, ctr, position)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(site_id, date, query) DO UPDATE SET
+         clicks = excluded.clicks, impressions = excluded.impressions,
+         ctr = excluded.ctr, position = excluded.position`,
+    );
+    for (const site of sites) {
+      try {
+        const q = await sc.searchanalytics.query({
+          siteUrl: site.scUrl,
+          requestBody: { startDate, endDate, dimensions: ['query'], rowLimit: 50 },
+        });
+        const rows = q.data.rows || [];
+        const insertAll = db.transaction(() => {
+          for (const row of rows) {
+            kwInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
+          }
+        });
+        insertAll();
+        console.log(`  KW ${site.id}: ${rows.length} queries`);
+      } catch (e) {
+        console.log(`  KW ${site.id}: error - ${e.message.slice(0, 60)}`);
+      }
+    }
+
+    const ga4Auth = new GoogleAuth({
+      credentials: creds,
+      scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
+    });
+    const ga4Client = new BetaAnalyticsDataClient({ auth: ga4Auth });
+    const ga4Delete = db.prepare('DELETE FROM ga4_snapshots WHERE site_id = ? AND date = ?');
+    const ga4Insert = db.prepare('INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration) VALUES (?, ?, ?, ?, ?, ?, ?)');
+    const ga4Upsert = db.transaction((siteId, date, users, sessions, views, bounce, duration) => {
+      ga4Delete.run(siteId, date);
+      ga4Insert.run(siteId, date, users, sessions, views, bounce, duration);
+    });
+
+    for (const site of sites) {
+      if (!site.ga4) continue;
+      try {
+        const [report] = await ga4Client.runReport({
+          property: `properties/${site.ga4}`,
+          dateRanges: [{ startDate: '7daysAgo', endDate: 'yesterday' }],
+          metrics: [
+            { name: 'activeUsers' },
+            { name: 'sessions' },
+            { name: 'screenPageViews' },
+            { name: 'bounceRate' },
+            { name: 'averageSessionDuration' },
+          ],
+        });
+        const row = report.rows?.[0];
+        const users = parseInt(row?.metricValues?.[0]?.value || '0');
+        const sessions = parseInt(row?.metricValues?.[1]?.value || '0');
+        const views = parseInt(row?.metricValues?.[2]?.value || '0');
+        const bounce = parseFloat(row?.metricValues?.[3]?.value || '0');
+        const duration = parseFloat(row?.metricValues?.[4]?.value || '0');
+        ga4Upsert(site.id, today, users, sessions, views, bounce, duration);
+        console.log(`  GA4 ${site.id}: ${users} users, ${views} views`);
+      } catch (e) {
+        console.log(`  GA4 ${site.id}: error - ${e.message.slice(0, 60)}`);
+      }
+    }
+
+    finishSnapshotRun({ lockOwner, success: true });
+    console.log(`\nSnapshot saved for ${today}`);
+  } catch (error) {
+    finishSnapshotRun({ lockOwner, success: false, error });
+    throw error;
+  }
+}
+
+function acquireSnapshotLock(now = Date.now()) {
+  const lockOwner = randomUUID();
+  const upsertRunning = db.prepare(`
+    INSERT INTO snapshot_runs (job_key, status, last_started_at, last_finished_at, last_error, lock_owner)
+    VALUES (?, 'running', ?, NULL, NULL, ?)
+    ON CONFLICT(job_key) DO UPDATE SET
+      status = 'running',
+      last_started_at = excluded.last_started_at,
+      last_finished_at = NULL,
+      last_error = NULL,
+      lock_owner = excluded.lock_owner
+    WHERE snapshot_runs.status != 'running'
+      OR snapshot_runs.last_started_at IS NULL
+      OR ? - snapshot_runs.last_started_at >= ?
+  `);
+
+  const result = upsertRunning.run(SNAPSHOT_JOB_KEY, now, lockOwner, now, SNAPSHOT_STALE_LOCK_MS);
+  if (result.changes === 0) {
+    throw new Error('snapshot_in_progress');
+  }
+  return lockOwner;
+}
+
+function finishSnapshotRun({ lockOwner, success, error, now = Date.now() }) {
+  if (success) {
+    db.prepare(`
+      UPDATE snapshot_runs
+      SET status = 'idle',
+        last_finished_at = ?,
+        last_success_at = ?,
+        last_error = NULL,
+        lock_owner = NULL
+      WHERE job_key = ? AND lock_owner = ?
+    `).run(now, now, SNAPSHOT_JOB_KEY, lockOwner);
+    return;
   }
 
-  const kwInsert = db.prepare(
-    `INSERT INTO keyword_history (site_id, date, query, clicks, impressions, ctr, position)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(site_id, date, query) DO UPDATE SET
-       clicks = excluded.clicks, impressions = excluded.impressions,
-       ctr = excluded.ctr, position = excluded.position`,
+  db.prepare(`
+    UPDATE snapshot_runs
+    SET status = 'idle',
+      last_finished_at = ?,
+      last_failure_at = ?,
+      last_error = ?,
+      lock_owner = NULL
+    WHERE job_key = ? AND lock_owner = ?
+  `).run(
+    now,
+    now,
+    error instanceof Error ? error.message : String(error),
+    SNAPSHOT_JOB_KEY,
+    lockOwner,
   );
-  for (const site of sites) {
-    try {
-      const q = await sc.searchanalytics.query({
-        siteUrl: site.scUrl,
-        requestBody: { startDate, endDate, dimensions: ['query'], rowLimit: 50 },
-      });
-      const rows = q.data.rows || [];
-      const insertAll = db.transaction(() => {
-        for (const row of rows) {
-          kwInsert.run(site.id, today, row.keys?.[0] || '', row.clicks || 0, row.impressions || 0, row.ctr || 0, row.position || 0);
-        }
-      });
-      insertAll();
-      console.log(`  KW ${site.id}: ${rows.length} queries`);
-    } catch (e) {
-      console.log(`  KW ${site.id}: error - ${e.message.slice(0, 60)}`);
-    }
-  }
-
-  const ga4Auth = new GoogleAuth({
-    credentials: creds,
-    scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
-  });
-  const ga4Client = new BetaAnalyticsDataClient({ auth: ga4Auth });
-  const ga4Delete = db.prepare('DELETE FROM ga4_snapshots WHERE site_id = ? AND date = ?');
-  const ga4Insert = db.prepare('INSERT INTO ga4_snapshots (site_id, date, users, sessions, views, bounce_rate, avg_duration) VALUES (?, ?, ?, ?, ?, ?, ?)');
-  const ga4Upsert = db.transaction((siteId, date, users, sessions, views, bounce, duration) => {
-    ga4Delete.run(siteId, date);
-    ga4Insert.run(siteId, date, users, sessions, views, bounce, duration);
-  });
-
-  for (const site of sites) {
-    if (!site.ga4) continue;
-    try {
-      const [report] = await ga4Client.runReport({
-        property: `properties/${site.ga4}`,
-        dateRanges: [{ startDate: '7daysAgo', endDate: 'yesterday' }],
-        metrics: [
-          { name: 'activeUsers' },
-          { name: 'sessions' },
-          { name: 'screenPageViews' },
-          { name: 'bounceRate' },
-          { name: 'averageSessionDuration' },
-        ],
-      });
-      const row = report.rows?.[0];
-      const users = parseInt(row?.metricValues?.[0]?.value || '0');
-      const sessions = parseInt(row?.metricValues?.[1]?.value || '0');
-      const views = parseInt(row?.metricValues?.[2]?.value || '0');
-      const bounce = parseFloat(row?.metricValues?.[3]?.value || '0');
-      const duration = parseFloat(row?.metricValues?.[4]?.value || '0');
-      ga4Upsert(site.id, today, users, sessions, views, bounce, duration);
-      console.log(`  GA4 ${site.id}: ${users} users, ${views} views`);
-    } catch (e) {
-      console.log(`  GA4 ${site.id}: error - ${e.message.slice(0, 60)}`);
-    }
-  }
-
-  console.log(`\nSnapshot saved for ${today}`);
 }
 
 const UAS = [

--- a/src/lib/__tests__/snapshot.test.ts
+++ b/src/lib/__tests__/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -51,7 +51,13 @@ vi.mock('@google-analytics/data', () => ({
 }));
 
 import { getDb } from '../db';
-import { runSnapshot } from '../snapshot';
+import { discoverPropertyIds } from '../ga4';
+import {
+  getSnapshotRunState,
+  runSnapshot,
+  runSnapshotIfDue,
+  SnapshotAlreadyRunningError,
+} from '../snapshot';
 import { getScTrends, getGa4Trends, getTtfbTrends } from '../db';
 
 const fetchMock = vi.fn();
@@ -64,6 +70,7 @@ function resetDb() {
     DELETE FROM ga4_snapshots;
     DELETE FROM audit_snapshots;
     DELETE FROM keyword_history;
+    DELETE FROM snapshot_runs;
   `);
 }
 
@@ -112,6 +119,10 @@ beforeEach(() => {
   ga4ReportMock.mockResolvedValue([{
     rows: [{ metricValues: [{ value: '10' }, { value: '20' }, { value: '30' }, { value: '0.4' }, { value: '12.5' }] }],
   }]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('runSnapshot dedupe', () => {
@@ -230,5 +241,140 @@ describe('runSnapshot TTFB', () => {
     const result = await runSnapshot();
     expect(result.errors.some((e) => e.includes('Audit site-a'))).toBe(true);
     expect(result.ttfb).toBe(1); // site-b still succeeds
+  });
+
+  it('persists snapshot run timestamps after success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T08:00:00Z'));
+
+    await runSnapshot();
+
+    const now = Date.parse('2026-05-14T08:00:00Z');
+
+    expect(getSnapshotRunState()).toEqual({
+      status: 'idle',
+      last_started_at: now,
+      last_finished_at: now,
+      last_success_at: now,
+      last_failure_at: null,
+      last_error: null,
+    });
+  });
+
+  it('persists failure metadata when snapshot throws before any site work starts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T09:00:00Z'));
+    vi.mocked(discoverPropertyIds).mockRejectedValueOnce(new Error('Discovery offline'));
+
+    await expect(runSnapshot()).rejects.toThrow('Discovery offline');
+
+    const now = Date.parse('2026-05-14T09:00:00Z');
+
+    expect(getSnapshotRunState()).toEqual({
+      status: 'idle',
+      last_started_at: now,
+      last_finished_at: now,
+      last_success_at: null,
+      last_failure_at: now,
+      last_error: 'Discovery offline',
+    });
+  });
+});
+
+describe('runSnapshotIfDue', () => {
+  it('runs immediately when no successful snapshot exists yet', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T10:00:00Z'));
+
+    await expect(runSnapshotIfDue()).resolves.toBe('started');
+    expect(scQueryMock).toHaveBeenCalled();
+  });
+
+  it('skips when the last successful snapshot is still within the schedule window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T10:00:00Z'));
+    await runSnapshot();
+    scQueryMock.mockClear();
+
+    vi.setSystemTime(new Date('2026-05-14T20:00:00Z'));
+    await expect(runSnapshotIfDue()).resolves.toBe('skipped-not-due');
+    expect(scQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped-running when persisted state is already in progress', async () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO snapshot_runs (
+        job_key, status, last_started_at, last_finished_at, last_success_at, last_failure_at, last_error, lock_owner
+      ) VALUES (?, 'running', ?, NULL, NULL, NULL, NULL, ?)`,
+    ).run('daily', Date.now(), 'existing-owner');
+
+    await expect(runSnapshotIfDue()).resolves.toBe('skipped-running');
+    expect(scQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a manual run when another process holds a fresh persisted lock', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T11:00:00Z'));
+    const db = getDb();
+    const startedAt = Date.now();
+    db.prepare(
+      `INSERT INTO snapshot_runs (
+        job_key, status, last_started_at, last_finished_at, last_success_at, last_failure_at, last_error, lock_owner
+      ) VALUES (?, 'running', ?, NULL, NULL, NULL, NULL, ?)`,
+    ).run('daily', startedAt, 'existing-owner');
+
+    await expect(runSnapshot()).rejects.toBeInstanceOf(SnapshotAlreadyRunningError);
+
+    const row = db.prepare(
+      'SELECT status, last_started_at, lock_owner FROM snapshot_runs WHERE job_key = ?',
+    ).get('daily') as { status: string; last_started_at: number; lock_owner: string };
+    expect(row).toEqual({
+      status: 'running',
+      last_started_at: startedAt,
+      lock_owner: 'existing-owner',
+    });
+    expect(scQueryMock).not.toHaveBeenCalled();
+  });
+
+  it('atomically replaces a stale persisted lock and only clears the new owner on finish', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T12:00:00Z'));
+    const db = getDb();
+    const staleStartedAt = Date.now() - (6 * 60 * 60 * 1000) - 1;
+    db.prepare(
+      `INSERT INTO snapshot_runs (
+        job_key, status, last_started_at, last_finished_at, last_success_at, last_failure_at, last_error, lock_owner
+      ) VALUES (?, 'running', ?, NULL, NULL, NULL, ?, ?)`,
+    ).run('daily', staleStartedAt, 'previous process crashed', 'stale-owner');
+
+    await expect(runSnapshot()).resolves.toMatchObject({ date: '2026-05-14' });
+
+    const now = Date.parse('2026-05-14T12:00:00Z');
+    const row = db.prepare(
+      'SELECT status, last_started_at, last_success_at, last_error, lock_owner FROM snapshot_runs WHERE job_key = ?',
+    ).get('daily') as {
+      status: string;
+      last_started_at: number;
+      last_success_at: number;
+      last_error: string | null;
+      lock_owner: string | null;
+    };
+    expect(row).toEqual({
+      status: 'idle',
+      last_started_at: now,
+      last_success_at: now,
+      last_error: null,
+      lock_owner: null,
+    });
+    expect(scQueryMock).toHaveBeenCalled();
+  });
+
+  it('throws SnapshotAlreadyRunningError on overlapping manual runs', async () => {
+    const first = runSnapshot();
+    await Promise.resolve();
+
+    await expect(runSnapshot()).rejects.toBeInstanceOf(SnapshotAlreadyRunningError);
+    await first;
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -9,7 +9,7 @@ const DB_PATH = path.join(process.cwd(), 'data', 'seo-tools.db');
 interface SqliteStatement<Result = unknown> {
   get(...params: unknown[]): Result;
   all(...params: unknown[]): Result[];
-  run(...params: unknown[]): unknown;
+  run(...params: unknown[]): { changes?: number };
 }
 
 export interface SqliteDatabase {
@@ -132,6 +132,17 @@ function initSchema(db: SqliteDatabase): void {
       submit_count INTEGER NOT NULL DEFAULT 0
     );
 
+    CREATE TABLE IF NOT EXISTS snapshot_runs (
+      job_key TEXT NOT NULL PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'idle',
+      last_started_at INTEGER,
+      last_finished_at INTEGER,
+      last_success_at INTEGER,
+      last_failure_at INTEGER,
+      last_error TEXT,
+      lock_owner TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS config (
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
@@ -170,6 +181,7 @@ function initSchema(db: SqliteDatabase): void {
   try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN sitemap_urls INTEGER`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN indexed_pages INTEGER`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE audit_snapshots ADD COLUMN coverage_pct INTEGER`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE snapshot_runs ADD COLUMN lock_owner TEXT`); } catch { /* already exists */ }
 }
 
 // --- Cache helpers ---

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
@@ -16,8 +17,24 @@ export interface SnapshotResult {
   errors: string[];
 }
 
-// Module-level lock — Next.js runs in a single process so this is sufficient.
+interface SnapshotRunRow {
+  status: 'idle' | 'running';
+  last_started_at: number | null;
+  last_finished_at: number | null;
+  last_success_at: number | null;
+  last_failure_at: number | null;
+  last_error: string | null;
+}
+
+type ScheduledSnapshotResult = 'started' | 'skipped-not-due' | 'skipped-running';
+
+const SNAPSHOT_JOB_KEY = 'daily';
+const SNAPSHOT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const SNAPSHOT_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const SNAPSHOT_STALE_LOCK_MS = 6 * 60 * 60 * 1000;
+
 let snapshotRunning = false;
+let schedulerIntervalId: ReturnType<typeof setInterval> | null = null;
 
 export class SnapshotAlreadyRunningError extends Error {
   constructor() {
@@ -27,19 +44,159 @@ export class SnapshotAlreadyRunningError extends Error {
 }
 
 export function isSnapshotRunning(): boolean {
-  return snapshotRunning;
+  if (snapshotRunning) {
+    return true;
+  }
+  return hasFreshLock(getSnapshotRunState());
 }
 
 export async function runSnapshot(): Promise<SnapshotResult> {
   if (snapshotRunning) {
     throw new SnapshotAlreadyRunningError();
   }
+  const lockOwner = acquireSnapshotLock();
   snapshotRunning = true;
   try {
-    return await doSnapshot();
+    const result = await doSnapshot();
+    finishSnapshotRun({ lockOwner, success: true });
+    return result;
+  } catch (error) {
+    finishSnapshotRun({ lockOwner, success: false, error });
+    throw error;
   } finally {
     snapshotRunning = false;
   }
+}
+
+export function getSnapshotRunState(): SnapshotRunRow {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT status, last_started_at, last_finished_at, last_success_at, last_failure_at, last_error
+     FROM snapshot_runs WHERE job_key = ?`,
+  ).get(SNAPSHOT_JOB_KEY) as SnapshotRunRow | undefined;
+
+  return row ?? {
+    status: 'idle',
+    last_started_at: null,
+    last_finished_at: null,
+    last_success_at: null,
+    last_failure_at: null,
+    last_error: null,
+  };
+}
+
+export async function runSnapshotIfDue(now: number = Date.now()): Promise<ScheduledSnapshotResult> {
+  const state = getSnapshotRunState();
+  if (snapshotRunning || hasFreshLock(state, now)) {
+    return 'skipped-running';
+  }
+  if (!isSnapshotDue(state, now)) {
+    return 'skipped-not-due';
+  }
+
+  await runSnapshot();
+  return 'started';
+}
+
+export function startSnapshotScheduler(): void {
+  if (schedulerIntervalId) {
+    return;
+  }
+
+  runSnapshotIfDue().catch((error) => {
+    console.error('[snapshot] startup check failed:', (error as Error).message);
+  });
+
+  schedulerIntervalId = setInterval(() => {
+    runSnapshotIfDue().catch((error) => {
+      console.error('[snapshot] scheduled run failed:', (error as Error).message);
+    });
+  }, SNAPSHOT_CHECK_INTERVAL_MS);
+
+  console.log(
+    `[snapshot] Scheduled due-check every ${SNAPSHOT_CHECK_INTERVAL_MS / 3_600_000}h (window ${SNAPSHOT_INTERVAL_MS / 3_600_000}h)`,
+  );
+}
+
+function isSnapshotDue(state: SnapshotRunRow, now: number): boolean {
+  if (state.last_success_at === null) {
+    return true;
+  }
+  return now - state.last_success_at >= SNAPSHOT_INTERVAL_MS;
+}
+
+function hasFreshLock(state: SnapshotRunRow, now: number = Date.now()): boolean {
+  return state.status === 'running'
+    && typeof state.last_started_at === 'number'
+    && now - state.last_started_at < SNAPSHOT_STALE_LOCK_MS;
+}
+
+function acquireSnapshotLock(now: number = Date.now()): string {
+  const db = getDb();
+  const lockOwner = randomUUID();
+  const upsertRunning = db.prepare(
+    `INSERT INTO snapshot_runs (
+       job_key, status, last_started_at, last_finished_at, last_error, lock_owner
+     )
+     VALUES (?, 'running', ?, NULL, NULL, ?)
+     ON CONFLICT(job_key) DO UPDATE SET
+       status = 'running',
+       last_started_at = excluded.last_started_at,
+       last_finished_at = NULL,
+       last_error = NULL,
+       lock_owner = excluded.lock_owner
+     WHERE snapshot_runs.status != 'running'
+       OR snapshot_runs.last_started_at IS NULL
+       OR ? - snapshot_runs.last_started_at >= ?`,
+  );
+
+  const result = upsertRunning.run(SNAPSHOT_JOB_KEY, now, lockOwner, now, SNAPSHOT_STALE_LOCK_MS);
+  if (result.changes === 0) {
+    throw new SnapshotAlreadyRunningError();
+  }
+  return lockOwner;
+}
+
+function finishSnapshotRun({
+  lockOwner,
+  success,
+  error,
+  now = Date.now(),
+}: {
+  lockOwner: string;
+  success: boolean;
+  error?: unknown;
+  now?: number;
+}): void {
+  const db = getDb();
+  if (success) {
+    db.prepare(
+      `UPDATE snapshot_runs
+       SET status = 'idle',
+         last_finished_at = ?,
+         last_success_at = ?,
+         last_error = NULL,
+         lock_owner = NULL
+       WHERE job_key = ? AND lock_owner = ?`,
+    ).run(now, now, SNAPSHOT_JOB_KEY, lockOwner);
+    return;
+  }
+
+  db.prepare(
+    `UPDATE snapshot_runs
+     SET status = 'idle',
+       last_finished_at = ?,
+       last_failure_at = ?,
+       last_error = ?,
+       lock_owner = NULL
+     WHERE job_key = ? AND lock_owner = ?`,
+  ).run(
+    now,
+    now,
+    error instanceof Error ? error.message : String(error),
+    SNAPSHOT_JOB_KEY,
+    lockOwner,
+  );
 }
 
 async function doSnapshot(): Promise<SnapshotResult> {


### PR DESCRIPTION
Closes #16

Implemented issue `#16` by adding persisted snapshot scheduling/lock state, wiring startup scheduling, and updating snapshot tests; the CLI now mirrors the same run-state metadata without attempting an unsafe direct TS import.

---
Implemented via TamTam from issue [#16](https://github.com/3h4x/seo-tools/issues/16).