### PR TITLE
fix: Keep managed-site deletion UI consistent when the delete API fails

### DIFF
--- a/app/components/sites-manager.tsx
+++ b/app/components/sites-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { applyImportResults, buildImportSummary, getImportResult, type DiscoverySite, type ImportResult, type ImportSummary } from '@/lib/discovery-import';
+import { getMutationResult } from '@/lib/request-result';
 import { getSiteScUrlOverride, isReservedSiteId, isValidSiteDomain, isValidSiteId, normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
 import type { SiteDiagnosticResult } from '@/lib/site-diagnostics';
 import { SKIP_CHECK_OPTIONS, hasSkipCheck, toggleSkipCheck } from '@/lib/skip-checks';
@@ -234,9 +235,9 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
           originalId: editMode === 'new' ? undefined : form.id,
         }),
       });
-      const data = await res.json() as { ok: boolean; error?: string };
-      if (!data.ok) {
-        setError(data.error ?? 'Save failed');
+      const result = await getMutationResult(res, 'Save failed');
+      if (!result.ok) {
+        setError(result.error ?? 'Save failed');
         return;
       }
       await reloadSites();
@@ -250,7 +251,13 @@ export default function SitesManager({ initialSites, hasAuth }: Props) {
 
   async function handleDelete(id: string) {
     try {
-      await fetch(`/api/sites?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+      setError('');
+      const res = await fetch(`/api/sites?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+      const result = await getMutationResult(res, 'Delete failed');
+      if (!result.ok) {
+        setError(result.error ?? 'Delete failed');
+        return;
+      }
       setSites(prev => prev.filter(s => s.id !== id));
       setDeleteConfirm(null);
       if (editMode === id) setEditMode('none');

--- a/src/lib/__tests__/request-result.test.ts
+++ b/src/lib/__tests__/request-result.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getMutationResult } from '../request-result';
+
+describe('getMutationResult', () => {
+  it('returns ok for successful mutation payloads', async () => {
+    const response = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getMutationResult(response, 'Delete failed')).resolves.toEqual({ ok: true });
+  });
+
+  it('surfaces payload errors for non-2xx responses', async () => {
+    const response = new Response(JSON.stringify({ ok: false, error: 'Site is still referenced' }), {
+      status: 409,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getMutationResult(response, 'Delete failed')).resolves.toEqual({
+      ok: false,
+      error: 'Site is still referenced',
+    });
+  });
+
+  it('treats 2xx payload failures as errors instead of success', async () => {
+    const response = new Response(JSON.stringify({ ok: false, error: 'Delete rejected' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(getMutationResult(response, 'Delete failed')).resolves.toEqual({
+      ok: false,
+      error: 'Delete rejected',
+    });
+  });
+
+  it('falls back to the caller-provided message when the payload is missing', async () => {
+    const response = new Response(null, { status: 200 });
+
+    await expect(getMutationResult(response, 'Delete failed')).resolves.toEqual({
+      ok: false,
+      error: 'Delete failed',
+    });
+  });
+});

--- a/src/lib/request-result.ts
+++ b/src/lib/request-result.ts
@@ -1,0 +1,35 @@
+type MutationPayload = {
+  ok?: boolean;
+  error?: string;
+};
+
+export type MutationResult = {
+  ok: boolean;
+  error?: string;
+};
+
+export async function getMutationResult(response: Response, fallbackError: string): Promise<MutationResult> {
+  let payload: MutationPayload | null = null;
+
+  try {
+    payload = await response.json() as MutationPayload;
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: payload?.error?.trim() || `Request failed (${response.status})`,
+    };
+  }
+
+  if (payload?.ok === true) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    error: payload?.error?.trim() || fallbackError,
+  };
+}


### PR DESCRIPTION
Closes #104

Validated issue `#104`, commented on it, created the TamTam issue branch, implemented the delete-response fix, and updated persistent memory.

---
Implemented via TamTam from issue [#104](https://github.com/3h4x/seo-tools/issues/104).