### PR TITLE
fix: Make GA4 auto-discovery refuse ambiguous substring matches and surface them for review

### DIFF
--- a/app/api/sites/discover/route.ts
+++ b/app/api/sites/discover/route.ts
@@ -5,7 +5,7 @@ import { dbGetSites } from '@/lib/db';
 import { cachedGetDiscoveredGa4Properties } from '@/lib/ga4';
 import { createUniqueSiteId, normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
 import { getSearchConsoleUrlIdentities, getSiteSearchConsoleIdentities, normalizeSearchConsoleIdentity, type Site } from '@/lib/sites';
-import { buildUniqueExactGa4Matches, findMatchingGa4Property, type DiscoveredGa4Property } from '@/lib/ga4-discovery';
+import { buildUniqueExactGa4Matches, findMatchingGa4Property, getSafeDomainVariants, type DiscoveredGa4Property } from '@/lib/ga4-discovery';
 
 type DiscoveredScSite = {
   scUrl: string;
@@ -102,6 +102,13 @@ function createDiscoveryIdAllocator(existingIds: Iterable<string>): (domain: str
   };
 }
 
+function hasDomainVariant(domain: string, domains: Set<string>): boolean {
+  for (const variant of getSafeDomainVariants(domain)) {
+    if (domains.has(variant)) return true;
+  }
+  return false;
+}
+
 export async function GET(req: Request) {
   let auth;
   try {
@@ -161,7 +168,7 @@ export async function GET(req: Request) {
   // Build proposed sites from the union of SC domains and GA4 properties not already in DB
   const proposedFromSc: DiscoveryCandidate[] = scSites
     .filter(({ domain, scUrls }) => {
-      if (existingDomains.has(domain.toLowerCase()) || existingScIdentities.has(domain.toLowerCase())) {
+      if (hasDomainVariant(domain, existingDomains) || hasDomainVariant(domain, existingScIdentities)) {
         return false;
       }
 
@@ -192,7 +199,13 @@ export async function GET(req: Request) {
   const proposed: DiscoveryCandidate[] = [...proposedFromSc];
 
   for (const [domain, ga4Match] of exactGa4Matches.entries()) {
-    if (proposedScDomains.has(domain) || existingDomains.has(domain) || existingScIdentities.has(domain)) continue;
+    if (
+      hasDomainVariant(domain, proposedScDomains) ||
+      hasDomainVariant(domain, existingDomains) ||
+      hasDomainVariant(domain, existingScIdentities)
+    ) {
+      continue;
+    }
 
     const matchedGa4Property = toMatchedGa4Property(ga4Match);
     if (!matchedGa4Property) continue;
@@ -220,7 +233,7 @@ export async function GET(req: Request) {
         ...site,
         ga4PropertyId: ga4Match.propertyId,
         ga4DisplayName: ga4Match.displayName,
-        discoverySource: scDomains.has(site.domain.toLowerCase()) ? 'sc+ga4' : 'ga4',
+        discoverySource: hasDomainVariant(site.domain, scDomains) ? 'sc+ga4' : 'ga4',
         isUpdate: true,
       }];
     });

--- a/src/lib/__tests__/api-discover.test.ts
+++ b/src/lib/__tests__/api-discover.test.ts
@@ -114,7 +114,7 @@ describe('GET /api/sites/discover', () => {
     expect(body[0].domain).not.toContain('sc-domain:');
   });
 
-  it('matches GA4 property by domain substring in display name', async () => {
+  it('matches GA4 property when the display name starts with the domain and a GA4 descriptor', async () => {
     mockSc(['mysite.com']);
     mockGa4([{ displayName: 'mysite.com - GA4', property: 'properties/123456' }]);
 
@@ -123,6 +123,45 @@ describe('GET /api/sites/discover', () => {
     expect(body[0].ga4PropertyId).toBe('properties/123456');
     expect(body[0].ga4DisplayName).toBe('mysite.com - GA4');
     expect(body[0].discoverySource).toBe('sc+ga4');
+  });
+
+  it('still auto-assigns a GA4 property for an approved www host variant', async () => {
+    mockSc(['www.mysite.com']);
+    mockGa4([{ displayName: 'mysite.com', property: 'properties/123456' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].ga4PropertyId).toBe('properties/123456');
+    expect(body[0].ga4DisplayName).toBe('mysite.com');
+    expect(body[0].discoverySource).toBe('sc+ga4');
+  });
+
+  it('does not create a duplicate GA4-only candidate for the reverse www host variant', async () => {
+    mockSc(['mysite.com']);
+    mockGa4([{ displayName: 'www.mysite.com', property: 'properties/123456' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      domain: 'mysite.com',
+      ga4PropertyId: 'properties/123456',
+      ga4DisplayName: 'www.mysite.com',
+      discoverySource: 'sc+ga4',
+    });
+  });
+
+  it('does not propose a GA4-only candidate for an existing site www host variant', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: 'properties/999' },
+    ] as never);
+    mockSc([]);
+    mockGa4([{ displayName: 'www.mysite.com', property: 'properties/123456' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toEqual([]);
   });
 
   it('includes GA4-only properties as discovery candidates when the display name is an exact domain', async () => {
@@ -565,6 +604,25 @@ describe('GET /api/sites/discover', () => {
       id: 'mysite-com',
       domain: 'mysite.com',
       ga4PropertyId: 'properties/111',
+      isUpdate: true,
+    });
+  });
+
+  it('backfills existing site as SC plus GA4 when Search Console differs only by www', async () => {
+    vi.mocked(dbGetSites).mockReturnValue([
+      { id: 'mysite-com', name: 'My Site', domain: 'mysite.com', testPages: ['/'], ga4PropertyId: undefined },
+    ] as never);
+    mockSc(['www.mysite.com']);
+    mockGa4([{ displayName: 'www.mysite.com', property: 'properties/111' }]);
+
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: 'mysite-com',
+      domain: 'mysite.com',
+      ga4PropertyId: 'properties/111',
+      discoverySource: 'sc+ga4',
       isUpdate: true,
     });
   });

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -144,7 +144,7 @@ describe('discoverPropertyIds', () => {
     expect(result[0].ga4PropertyId).toBeUndefined();
   });
 
-  it('matches when property displayName contains the domain', async () => {
+  it('does not match unsupported descriptive display names that only contain the domain as a substring', async () => {
     vi.mocked(getManagedSites).mockResolvedValue([
       { id: 's1', name: 'Site1', domain: 'bonker.wtf', testPages: [] },
     ] as never);
@@ -153,10 +153,10 @@ describe('discoverPropertyIds', () => {
     ]);
 
     const result = await discoverPropertyIds();
-    expect(result[0].ga4PropertyId).toBe('55555');
+    expect(result[0].ga4PropertyId).toBeUndefined();
   });
 
-  it('matches when site domain contains the property displayName', async () => {
+  it('matches when the only difference is a safe www host variant', async () => {
     vi.mocked(getManagedSites).mockResolvedValue([
       { id: 's1', name: 'Site1', domain: 'www.bonker.wtf', testPages: [] },
     ] as never);

--- a/src/lib/ga4-discovery.ts
+++ b/src/lib/ga4-discovery.ts
@@ -15,7 +15,35 @@ interface SiteLike {
 
 type PreparedGa4Property = DiscoveredGa4Property & {
   exactDomain?: string;
+  matchDomain?: string;
 };
+
+export function getSafeDomainVariants(domain: string): Set<string> {
+  const normalized = normalizeSiteDomain(domain);
+  if (!normalized) return new Set();
+
+  const variants = new Set([normalized]);
+  if (normalized.startsWith('www.')) {
+    variants.add(normalized.slice(4));
+  } else {
+    variants.add(`www.${normalized}`);
+  }
+
+  return variants;
+}
+
+function parseLeadingDomainDisplayName(displayName: string): string | undefined {
+  const match = displayName.match(/^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+)(.*)$/i);
+  if (!match) return undefined;
+
+  const domain = normalizeSiteDomain(match[1]);
+  if (!domain) return undefined;
+
+  const descriptor = match[2].trim().replace(/^[-_:|/()[\]\s]+/, '').trim().toLowerCase();
+  if (!descriptor) return domain;
+
+  return /^(?:ga4|web|analytics)\b/.test(descriptor) ? domain : undefined;
+}
 
 function prepareGa4Properties(properties: DiscoveredGa4Property[]): PreparedGa4Property[] {
   const prepared: PreparedGa4Property[] = [];
@@ -25,10 +53,12 @@ function prepareGa4Properties(properties: DiscoveredGa4Property[]): PreparedGa4P
     const propertyId = property.propertyId.trim();
     if (!displayName || !propertyId) continue;
 
+    const exactDomain = normalizeSiteDomain(displayName) ?? undefined;
     prepared.push({
       displayName,
       propertyId,
-      exactDomain: normalizeSiteDomain(displayName) ?? undefined,
+      exactDomain,
+      matchDomain: exactDomain ?? parseLeadingDomainDisplayName(displayName),
     });
   }
 
@@ -59,14 +89,11 @@ export function buildUniqueExactGa4Matches(properties: DiscoveredGa4Property[]):
 }
 
 export function findMatchingGa4Property(domain: string, properties: DiscoveredGa4Property[]): DiscoveredGa4Property | undefined {
-  const domainLower = domain.trim().toLowerCase();
-  if (!domainLower) return undefined;
+  const safeVariants = getSafeDomainVariants(domain);
+  if (safeVariants.size === 0) return undefined;
 
   const matches = prepareGa4Properties(properties).filter((property) => {
-    if (property.exactDomain === domainLower) return true;
-
-    const displayName = property.displayName.toLowerCase();
-    return displayName.includes(domainLower) || domainLower.includes(displayName);
+    return property.matchDomain ? safeVariants.has(property.matchDomain) : false;
   });
 
   if (matches.length !== 1) return undefined;


### PR DESCRIPTION
Closes #102

Implemented issue `#102` by tightening GA4 discovery matching and updating regression tests without running verification.

---
Implemented via TamTam from issue [#102](https://github.com/3h4x/seo-tools/issues/102).