### PR TITLE
fix: Make GA4-backed collectors and diagnostics work with stored properties/NNNNNN IDs

### DIFF
--- a/app/api/sites/discover/route.ts
+++ b/app/api/sites/discover/route.ts
@@ -3,6 +3,7 @@ import { getAuth } from '@/lib/google-auth';
 import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { dbGetSites } from '@/lib/db';
 import { cachedGetDiscoveredGa4Properties } from '@/lib/ga4';
+import { normalizeGa4PropertyId } from '@/lib/ga4-property';
 import { createUniqueSiteId, normalizeSiteDomain, slugifySiteDomain } from '@/lib/site-domain';
 import { getSearchConsoleUrlIdentities, getSiteSearchConsoleIdentities, normalizeSearchConsoleIdentity, type Site } from '@/lib/sites';
 import { buildUniqueExactGa4Matches, findMatchingGa4Property, getSafeDomainVariants, type DiscoveredGa4Property } from '@/lib/ga4-discovery';
@@ -70,12 +71,6 @@ function dedupeScSites(scSites: DiscoveredScSite[]): DedupeScSite[] {
 
 function getExistingDomainIdentity(domain: string): string {
   return normalizeSiteDomain(domain) ?? domain.trim().toLowerCase();
-}
-
-function normalizeGa4PropertyId(propertyId: string): string | undefined {
-  const trimmed = propertyId.trim();
-  if (!trimmed) return undefined;
-  return trimmed.startsWith('properties/') ? trimmed : `properties/${trimmed}`;
 }
 
 function toMatchedGa4Property(property: DiscoveredGa4Property | undefined): MatchedGa4Property | undefined {

--- a/scripts/collect-daily.mjs
+++ b/scripts/collect-daily.mjs
@@ -13,6 +13,7 @@ import { searchconsole_v1 } from '@googleapis/searchconsole';
 import path from 'node:path';
 import fs from 'node:fs';
 import { openDatabase } from '../src/lib/sqlite-driver.js';
+import { normalizeGa4PropertyId } from './ga4-property.mjs';
 
 // Init DB
 const dbDir = path.join(process.cwd(), 'data');
@@ -210,7 +211,8 @@ const ga4Auth = new GoogleAuth({
 });
 const ga4Client = new BetaAnalyticsDataClient({ auth: ga4Auth });
 
-for (const site of SITES.filter(s => s.ga4)) {
+for (const site of SITES.filter(s => normalizeGa4PropertyId(s.ga4))) {
+  const ga4PropertyId = normalizeGa4PropertyId(site.ga4);
   const missing = getMissing('ga4_daily', site.id);
   if (missing.length === 0) {
     console.log(`  GA4 ${site.id}: up to date`);
@@ -223,7 +225,7 @@ for (const site of SITES.filter(s => s.ga4)) {
   for (const range of ranges) {
     try {
       const [report] = await ga4Client.runReport({
-        property: `properties/${site.ga4}`,
+        property: ga4PropertyId,
         dateRanges: [{ startDate: range.start, endDate: range.end }],
         dimensions: [{ name: 'date' }],
         metrics: [

--- a/scripts/ga4-property.mjs
+++ b/scripts/ga4-property.mjs
@@ -1,0 +1,10 @@
+const GA4_PROPERTY_PREFIX = 'properties/';
+
+export function normalizeGa4PropertyId(propertyId) {
+  const trimmed = propertyId?.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.startsWith(GA4_PROPERTY_PREFIX)
+    ? trimmed
+    : `${GA4_PROPERTY_PREFIX}${trimmed}`;
+}

--- a/scripts/seo.mjs
+++ b/scripts/seo.mjs
@@ -5,6 +5,7 @@ import { searchconsole_v1 } from '@googleapis/searchconsole';
 import path from 'node:path';
 import fs from 'node:fs';
 import { openDatabase } from '../src/lib/sqlite-driver.js';
+import { normalizeGa4PropertyId } from './ga4-property.mjs';
 
 // Init DB and load SA key
 const dbDir = path.join(process.cwd(), 'data');
@@ -245,10 +246,11 @@ async function takeSnapshot() {
     });
 
     for (const site of sites) {
-      if (!site.ga4) continue;
+      const ga4PropertyId = normalizeGa4PropertyId(site.ga4);
+      if (!ga4PropertyId) continue;
       try {
         const [report] = await ga4Client.runReport({
-          property: `properties/${site.ga4}`,
+          property: ga4PropertyId,
           dateRanges: [{ startDate: '7daysAgo', endDate: 'yesterday' }],
           metrics: [
             { name: 'activeUsers' },

--- a/src/lib/__tests__/collect-daily.test.ts
+++ b/src/lib/__tests__/collect-daily.test.ts
@@ -92,7 +92,7 @@ function mockSites() {
   };
 
   vi.mocked(getManagedSites).mockResolvedValue([site]);
-  vi.mocked(discoverPropertyIds).mockResolvedValue([{ ...site, ga4PropertyId: '123' }]);
+  vi.mocked(discoverPropertyIds).mockResolvedValue([{ ...site, ga4PropertyId: 'properties/123' }]);
   vi.mocked(getSCUrl).mockReturnValue('sc-domain:example.com');
   vi.mocked(getAuth).mockReturnValue('auth' as never);
 
@@ -498,7 +498,7 @@ describe('startCollector', () => {
       domain: 'example.com',
       searchConsole: false,
       testPages: [],
-      ga4PropertyId: '123',
+      ga4PropertyId: 'properties/123',
     }]);
     vi.mocked(getSCUrl).mockReturnValue('sc-domain:example.com');
     vi.mocked(getAuth).mockReturnValue('auth' as never);

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -60,7 +60,7 @@ describe('discoverPropertyIds', () => {
     ]);
 
     const result = await discoverPropertyIds();
-    expect(result[0].ga4PropertyId).toBe('12345');
+    expect(result[0].ga4PropertyId).toBe('properties/12345');
   });
 
   it('does not auto-assign GA4 when multiple exact-domain properties match the same site', async () => {
@@ -82,14 +82,14 @@ describe('discoverPropertyIds', () => {
 
   it('keeps existing ga4PropertyId if already set', async () => {
     vi.mocked(getManagedSites).mockResolvedValue([
-      { id: 's1', name: 'Site1', domain: 'example.com', ga4PropertyId: '99999', testPages: [] },
+      { id: 's1', name: 'Site1', domain: 'example.com', ga4PropertyId: 'properties/99999', testPages: [] },
     ] as never);
     mockListAccountSummaries.mockResolvedValue([
       [{ propertySummaries: [{ displayName: 'example.com', property: 'properties/12345' }] }],
     ]);
 
     const result = await discoverPropertyIds();
-    expect(result[0].ga4PropertyId).toBe('99999');
+    expect(result[0].ga4PropertyId).toBe('properties/99999');
   });
 
   it('leaves ga4PropertyId undefined when no match found', async () => {
@@ -165,7 +165,7 @@ describe('discoverPropertyIds', () => {
     ]);
 
     const result = await discoverPropertyIds();
-    expect(result[0].ga4PropertyId).toBe('22222');
+    expect(result[0].ga4PropertyId).toBe('properties/22222');
   });
 
   it('ignores properties without a displayName match', async () => {
@@ -422,6 +422,24 @@ describe('cachedGetAnalytics', () => {
 
     await cachedGetAnalytics('99999');
 
+    expect(mockRunReport).toHaveBeenCalledWith(
+      expect.objectContaining({ property: 'properties/99999' }),
+    );
+  });
+
+  it('reuses the normalized cache key for prefixed property ids', async () => {
+    mockRunReport
+      .mockResolvedValueOnce([{ rows: [] }])
+      .mockResolvedValueOnce([{ rows: [] }])
+      .mockResolvedValueOnce([{ rows: [] }]);
+
+    await cachedGetAnalytics('properties/99999');
+
+    expect(withCache).toHaveBeenCalledWith(
+      'ga4-7',
+      'properties/99999',
+      expect.any(Function),
+    );
     expect(mockRunReport).toHaveBeenCalledWith(
       expect.objectContaining({ property: 'properties/99999' }),
     );

--- a/src/lib/__tests__/script-ga4-property.test.ts
+++ b/src/lib/__tests__/script-ga4-property.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeGa4PropertyId } from '../../../scripts/ga4-property.mjs';
+
+describe('script normalizeGa4PropertyId', () => {
+  it('prefixes bare numeric property IDs', () => {
+    expect(normalizeGa4PropertyId('123')).toBe('properties/123');
+  });
+
+  it('keeps already-prefixed property IDs unchanged', () => {
+    expect(normalizeGa4PropertyId('properties/123')).toBe('properties/123');
+  });
+
+  it('ignores empty values', () => {
+    expect(normalizeGa4PropertyId('   ')).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
 
 describe('invalidateManagedSiteCache', () => {
   it('clears all cache families for a new managed site identity', () => {
-    const site = makeSite({ ga4PropertyId: '1234' });
+    const site = makeSite({ ga4PropertyId: 'properties/1234' });
 
     invalidateManagedSiteCache(null, site);
 
@@ -39,20 +39,20 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-data-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-queries-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-pages-', 'sc-domain:example.com');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
   });
 
   it('clears Search Console and GA4 caches for previous and next identities when updating', () => {
     const previous = makeSite({
       domain: 'old.example.com',
       scUrl: 'sc-domain:old.example.com',
-      ga4PropertyId: '1234',
+      ga4PropertyId: 'properties/1234',
     });
     const next = makeSite({
       domain: 'new.example.com',
       scUrl: 'sc-domain:new.example.com',
-      ga4PropertyId: '5678',
+      ga4PropertyId: 'properties/5678',
     });
 
     invalidateManagedSiteCache(previous, next);
@@ -60,21 +60,21 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:old.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '5678');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '5678');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/5678');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/5678');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
   });
 
   it('clears sitemap sync state when the Search Console identity changes but the domain stays the same', () => {
     const previous = makeSite({
       scUrl: 'https://example.com/',
-      ga4PropertyId: '1234',
+      ga4PropertyId: 'properties/1234',
     });
     const next = makeSite({
       scUrl: 'sc-domain:example.com',
-      ga4PropertyId: '1234',
+      ga4PropertyId: 'properties/1234',
     });
 
     invalidateManagedSiteCache(previous, next);
@@ -84,8 +84,8 @@ describe('invalidateManagedSiteCache', () => {
   });
 
   it('does not clear sitemap sync state for non-sitemap identity changes', () => {
-    const previous = makeSite({ name: 'Old Name', ga4PropertyId: '1234' });
-    const next = makeSite({ name: 'New Name', ga4PropertyId: '5678' });
+    const previous = makeSite({ name: 'Old Name', ga4PropertyId: 'properties/1234' });
+    const next = makeSite({ name: 'New Name', ga4PropertyId: 'properties/5678' });
 
     invalidateManagedSiteCache(previous, next);
 
@@ -94,7 +94,7 @@ describe('invalidateManagedSiteCache', () => {
   });
 
   it('clears sitemap sync state when deleting a managed site', () => {
-    const previous = makeSite({ ga4PropertyId: '1234' });
+    const previous = makeSite({ ga4PropertyId: 'properties/1234' });
 
     invalidateManagedSiteCache(previous, null);
 
@@ -103,18 +103,27 @@ describe('invalidateManagedSiteCache', () => {
   });
 
   it('does not clear duplicate identities twice', () => {
-    const previous = makeSite({ ga4PropertyId: '1234' });
-    const next = makeSite({ ga4PropertyId: '1234' });
+    const previous = makeSite({ ga4PropertyId: 'properties/1234' });
+    const next = makeSite({ ga4PropertyId: 'properties/1234' });
 
     invalidateManagedSiteCache(previous, next);
 
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
     expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', '1234');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', '1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
     expect(clearCacheEntry).toHaveBeenCalledTimes(2);
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(6);
     expect(clearSitemapSyncState).not.toHaveBeenCalled();
+  });
+
+  it('normalizes numeric GA4 ids before clearing cache families', () => {
+    const site = makeSite({ ga4PropertyId: '1234' });
+
+    invalidateManagedSiteCache(null, site);
+
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
   });
 });

--- a/src/lib/__tests__/snapshot.test.ts
+++ b/src/lib/__tests__/snapshot.test.ts
@@ -17,8 +17,8 @@ vi.mock('../google-auth', () => ({
 }));
 
 const mockSites = vi.hoisted(() => [
-  { id: 'site-a', domain: 'a.example.com', ga4PropertyId: '111', searchConsole: true, skipChecks: [] as string[] },
-  { id: 'site-b', domain: 'b.example.com', ga4PropertyId: '222', searchConsole: true, skipChecks: [] as string[] },
+  { id: 'site-a', domain: 'a.example.com', ga4PropertyId: 'properties/111', searchConsole: true, skipChecks: [] as string[] },
+  { id: 'site-b', domain: 'b.example.com', ga4PropertyId: 'properties/222', searchConsole: true, skipChecks: [] as string[] },
 ]);
 
 vi.mock('../ga4', () => ({

--- a/src/lib/collect-daily.ts
+++ b/src/lib/collect-daily.ts
@@ -4,6 +4,7 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getDb, upsertScDaily, upsertGa4Daily } from './db';
 import { getManagedSites, getSCUrl } from './sites';
 import { discoverPropertyIds } from './ga4';
+import { normalizeGa4PropertyId } from './ga4-property';
 
 const LOOKBACK_DAYS = 90;
 const COLLECT_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -153,7 +154,8 @@ async function collectDaily(): Promise<void> {
   const enrichedSites = await discoverPropertyIds();
 
   for (const site of enrichedSites) {
-    if (!site.ga4PropertyId) continue;
+    const propertyId = normalizeGa4PropertyId(site.ga4PropertyId);
+    if (!propertyId) continue;
 
     const missing = getMissingDates('ga4_daily', site.id, 'ga4', startDate, ga4EndDate);
     if (missing.length === 0) {
@@ -167,7 +169,7 @@ async function collectDaily(): Promise<void> {
     for (const range of ranges) {
       try {
         const [report] = await ga4Client.runReport({
-          property: `properties/${site.ga4PropertyId}`,
+          property: propertyId,
           dateRanges: [{ startDate: range.start, endDate: range.end }],
           dimensions: [{ name: 'date' }],
           metrics: [

--- a/src/lib/ga4-discovery.ts
+++ b/src/lib/ga4-discovery.ts
@@ -1,4 +1,5 @@
 import { normalizeSiteDomain } from './site-domain';
+import { normalizeGa4PropertyId } from './ga4-property';
 
 export const GA4_DISCOVERY_CACHE_KEY = 'ga4-discovery';
 export const GA4_DISCOVERY_CACHE_SITE_ID = 'managed-sites';
@@ -108,7 +109,7 @@ export function resolveSiteGa4PropertyId(
   site: SiteLike,
   properties: DiscoveredGa4Property[],
 ): string | undefined {
-  if (site.ga4PropertyId) return site.ga4PropertyId;
+  if (site.ga4PropertyId) return normalizeGa4PropertyId(site.ga4PropertyId);
 
-  return findMatchingGa4Property(site.domain, properties)?.propertyId;
+  return normalizeGa4PropertyId(findMatchingGa4Property(site.domain, properties)?.propertyId);
 }

--- a/src/lib/ga4-property.ts
+++ b/src/lib/ga4-property.ts
@@ -1,0 +1,10 @@
+const GA4_PROPERTY_PREFIX = 'properties/';
+
+export function normalizeGa4PropertyId(propertyId: string | null | undefined): string | undefined {
+  const trimmed = propertyId?.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.startsWith(GA4_PROPERTY_PREFIX)
+    ? trimmed
+    : `${GA4_PROPERTY_PREFIX}${trimmed}`;
+}

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -3,6 +3,7 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getManagedSites } from './sites';
 import { clearCacheEntry, withCache, type ProviderResult } from './db';
+import { normalizeGa4PropertyId } from './ga4-property';
 import {
   GA4_DISCOVERY_CACHE_KEY,
   GA4_DISCOVERY_CACHE_SITE_ID,
@@ -23,7 +24,7 @@ async function fetchDiscoveredGa4Properties(): Promise<DiscoveredGa4Property[] |
     return summaries.flatMap((account) => (
       (account.propertySummaries ?? []).flatMap((property) => {
         const displayName = property.displayName?.trim();
-        const propertyId = property.property?.split('/')[1]?.trim();
+        const propertyId = normalizeGa4PropertyId(property.property);
         if (!displayName || !propertyId) return [];
         return [{ displayName, propertyId }];
       })
@@ -93,15 +94,14 @@ interface GA4Data {
 }
 
 async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Data | null> {
-  if (!propertyId) return null;
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return null;
 
   try {
-    const prop = propertyId.startsWith('properties/') ? propertyId : `properties/${propertyId}`;
-
     const dataClient = getDataClient();
     const [metricsRes, topPagesRes, trafficRes] = await Promise.all([
       dataClient.runReport({
-        property: prop,
+        property: normalizedPropertyId,
         dateRanges: [
           { startDate: `${days}daysAgo`, endDate: 'yesterday' },
           { startDate: `${days * 2}daysAgo`, endDate: `${days + 1}daysAgo` },
@@ -115,7 +115,7 @@ async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Da
         ],
       }),
       dataClient.runReport({
-        property: prop,
+        property: normalizedPropertyId,
         dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
         dimensions: [{ name: 'pagePath' }],
         metrics: [
@@ -128,7 +128,7 @@ async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Da
         limit: 15,
       }),
       dataClient.runReport({
-        property: prop,
+        property: normalizedPropertyId,
         dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
         dimensions: [
           { name: 'sessionSource' },
@@ -180,13 +180,14 @@ async function getAnalytics(propertyId: string, days: number = 7): Promise<GA4Da
       trafficSources,
     };
   } catch (error) {
-    console.error(`Error fetching GA4 data for property ${propertyId}:`, error);
+    console.error(`Error fetching GA4 data for property ${normalizedPropertyId}:`, error);
     return null;
   }
 }
 
 export async function cachedGetAnalytics(propertyId: string, days: number = 7): Promise<ProviderResult<GA4Data>> {
-  if (!propertyId) return { data: null, error: false };
-  const data = await withCache<GA4Data>(`ga4-${days}`, propertyId, () => getAnalytics(propertyId, days));
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return { data: null, error: false };
+  const data = await withCache<GA4Data>(`ga4-${days}`, normalizedPropertyId, () => getAnalytics(normalizedPropertyId, days));
   return data !== null ? { data, error: false } : { data: null, error: true };
 }

--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -2,6 +2,7 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { withCache } from './db';
 import { CWV_METRIC_ORDER, type CwvMetricName, type CwvRating, rateCwv } from './constants';
+import { normalizeGa4PropertyId } from './ga4-property';
 
 function getDataClient() {
   return new BetaAnalyticsDataClient({ auth: getAuth() });
@@ -99,12 +100,13 @@ function emptyRumData(): RumCwvData {
 }
 
 async function getRumCoreWebVitals(propertyId: string, days: number): Promise<RumCwvData | null> {
-  if (!propertyId) return null;
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return null;
 
   try {
     const client = getDataClient();
     const [res] = await client.runReport({
-      property: `properties/${propertyId}`,
+      property: normalizedPropertyId,
       dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
       dimensions: [{ name: DIM_METRIC_NAME }, { name: 'deviceCategory' }],
       metrics: [{ name: 'eventCount' }, { name: MET_METRIC_VALUE }],
@@ -147,17 +149,18 @@ async function getRumCoreWebVitals(propertyId: string, days: number): Promise<Ru
     };
   } catch (error) {
     if (isNotConfiguredError(error)) return emptyRumData();
-    console.error(`Error fetching RUM CWV for property ${propertyId}:`, error);
+    console.error(`Error fetching RUM CWV for property ${normalizedPropertyId}:`, error);
     return null;
   }
 }
 
 async function getRumCwvByPage(propertyId: string, days: number, limit: number = 20): Promise<RumCwvByPage[] | null> {
-  if (!propertyId) return null;
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return null;
   try {
     const client = getDataClient();
     const [res] = await client.runReport({
-      property: `properties/${propertyId}`,
+      property: normalizedPropertyId,
       dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
       dimensions: [{ name: 'pagePath' }, { name: DIM_METRIC_NAME }],
       metrics: [{ name: 'eventCount' }, { name: MET_METRIC_VALUE }],
@@ -187,17 +190,18 @@ async function getRumCwvByPage(propertyId: string, days: number, limit: number =
       .slice(0, limit);
   } catch (error) {
     if (isNotConfiguredError(error)) return [];
-    console.error(`Error fetching RUM CWV pages for property ${propertyId}:`, error);
+    console.error(`Error fetching RUM CWV pages for property ${normalizedPropertyId}:`, error);
     return null;
   }
 }
 
 async function getRumCwvTrend(propertyId: string, days: number): Promise<RumCwvTrendPoint[] | null> {
-  if (!propertyId) return null;
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return null;
   try {
     const client = getDataClient();
     const [res] = await client.runReport({
-      property: `properties/${propertyId}`,
+      property: normalizedPropertyId,
       dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
       dimensions: [{ name: 'date' }, { name: DIM_METRIC_NAME }],
       metrics: [{ name: 'eventCount' }, { name: MET_METRIC_VALUE }],
@@ -224,35 +228,39 @@ async function getRumCwvTrend(propertyId: string, days: number): Promise<RumCwvT
       .map(([date, agg]) => ({ date, metrics: finalize(agg) }));
   } catch (error) {
     if (isNotConfiguredError(error)) return [];
-    console.error(`Error fetching RUM CWV trend for property ${propertyId}:`, error);
+    console.error(`Error fetching RUM CWV trend for property ${normalizedPropertyId}:`, error);
     return null;
   }
 }
 
 export function cachedGetRumCoreWebVitals(propertyId: string, days: number = 7): Promise<RumCwvData | null> {
-  if (!propertyId) return Promise.resolve(null);
-  return withCache<RumCwvData>(`rum-cwv-${days}`, propertyId, () => getRumCoreWebVitals(propertyId, days));
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return Promise.resolve(null);
+  return withCache<RumCwvData>(`rum-cwv-${days}`, normalizedPropertyId, () => getRumCoreWebVitals(normalizedPropertyId, days));
 }
 
 export function cachedGetRumCwvByPage(propertyId: string, days: number = 7, limit: number = 20): Promise<RumCwvByPage[] | null> {
-  if (!propertyId) return Promise.resolve(null);
-  return withCache<RumCwvByPage[]>(`rum-cwv-pages-${days}-${limit}`, propertyId, () => getRumCwvByPage(propertyId, days, limit));
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return Promise.resolve(null);
+  return withCache<RumCwvByPage[]>(`rum-cwv-pages-${days}-${limit}`, normalizedPropertyId, () => getRumCwvByPage(normalizedPropertyId, days, limit));
 }
 
 export function cachedGetRumCwvTrend(propertyId: string, days: number = 30): Promise<RumCwvTrendPoint[] | null> {
-  if (!propertyId) return Promise.resolve(null);
-  return withCache<RumCwvTrendPoint[]>(`rum-cwv-trend-${days}`, propertyId, () => getRumCwvTrend(propertyId, days));
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return Promise.resolve(null);
+  return withCache<RumCwvTrendPoint[]>(`rum-cwv-trend-${days}`, normalizedPropertyId, () => getRumCwvTrend(normalizedPropertyId, days));
 }
 
 // Returns the count of core_web_vitals events in the last `days` days.
 // Used to distinguish "GTM not wired" (count = 0) from "wired but custom
 // dimensions still propagating" (count > 0 but full RUM query errors / empty).
 async function getCwvEventCount(propertyId: string, days: number): Promise<number | null> {
-  if (!propertyId) return null;
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return null;
   try {
     const client = getDataClient();
     const [res] = await client.runReport({
-      property: `properties/${propertyId}`,
+      property: normalizedPropertyId,
       dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'today' }],
       dimensions: [{ name: 'eventName' }],
       metrics: [{ name: 'eventCount' }],
@@ -262,12 +270,13 @@ async function getCwvEventCount(propertyId: string, days: number): Promise<numbe
     const row = (res.rows || [])[0];
     return parseInt(row?.metricValues?.[0]?.value || '0');
   } catch (error) {
-    console.error(`Error fetching CWV event count for property ${propertyId}:`, error);
+    console.error(`Error fetching CWV event count for property ${normalizedPropertyId}:`, error);
     return null;
   }
 }
 
 export function cachedGetCwvEventCount(propertyId: string, days: number = 7): Promise<number | null> {
-  if (!propertyId) return Promise.resolve(null);
-  return withCache<number>(`rum-cwv-events-${days}`, propertyId, () => getCwvEventCount(propertyId, days));
+  const normalizedPropertyId = normalizeGa4PropertyId(propertyId);
+  if (!normalizedPropertyId) return Promise.resolve(null);
+  return withCache<number>(`rum-cwv-events-${days}`, normalizedPropertyId, () => getCwvEventCount(normalizedPropertyId, days));
 }

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -1,5 +1,6 @@
 import { clearCache, clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyncState } from './db';
 import { getSCUrl, type Site } from './sites';
+import { normalizeGa4PropertyId } from './ga4-property';
 
 const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-'] as const;
 const GA4_PROPERTY_CACHE_PREFIXES = ['ga4-', 'rum-cwv-'] as const;
@@ -10,13 +11,13 @@ function getCacheIdentities(site: Site): {
   scSiteId: string;
   ga4PropertyId?: string;
 } {
-  const ga4PropertyId = site.ga4PropertyId?.trim();
+  const ga4PropertyId = normalizeGa4PropertyId(site.ga4PropertyId);
 
   return {
     auditSiteId: site.id,
     domain: site.domain.trim(),
     scSiteId: getSCUrl(site),
-    ga4PropertyId: ga4PropertyId ? ga4PropertyId : undefined,
+    ga4PropertyId,
   };
 }
 

--- a/src/lib/site-diagnostics.ts
+++ b/src/lib/site-diagnostics.ts
@@ -2,6 +2,7 @@ import { searchconsole_v1 } from '@googleapis/searchconsole';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getManagedSites, getSCUrl, type Site } from './sites';
+import { normalizeGa4PropertyId } from './ga4-property';
 
 export type DiagnosticStatus = 'ok' | 'missing-config' | 'permission-error' | 'not-found' | 'provider-error';
 
@@ -95,13 +96,14 @@ async function checkSearchConsoleAccess(site: Site): Promise<ProviderDiagnostic>
 }
 
 async function checkGa4Access(site: Site): Promise<ProviderDiagnostic> {
-  if (!site.ga4PropertyId) {
+  const propertyId = normalizeGa4PropertyId(site.ga4PropertyId);
+  if (!propertyId) {
     return { status: 'missing-config', message: 'No GA4 property ID' };
   }
 
   try {
     await getGa4Client().runReport({
-      property: site.ga4PropertyId,
+      property: propertyId,
       dateRanges: [{ startDate: 'yesterday', endDate: 'yesterday' }],
       metrics: [{ name: 'activeUsers' }],
       limit: 1,

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -4,6 +4,7 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { getAuth } from './google-auth';
 import { getDb } from './db';
 import { discoverPropertyIds } from './ga4';
+import { normalizeGa4PropertyId } from './ga4-property';
 import { getSCUrl } from './sites';
 import { runSiteAudit } from './audit';
 import { normalizeSkipChecks } from './skip-checks';
@@ -287,9 +288,8 @@ async function doSnapshot(): Promise<SnapshotResult> {
   for (const site of sites) {
     if (!site.ga4PropertyId) continue;
     try {
-      const prop = site.ga4PropertyId.startsWith('properties/')
-        ? site.ga4PropertyId
-        : `properties/${site.ga4PropertyId}`;
+      const prop = normalizeGa4PropertyId(site.ga4PropertyId);
+      if (!prop) continue;
       const [report] = await ga4Client.runReport({
         property: prop,
         dateRanges: [{ startDate: '7daysAgo', endDate: 'yesterday' }],


### PR DESCRIPTION
Closes #101

Picked issue #101, validated it against current HEAD, created the TamTam issue branch, and implemented the GA4 property-id normalization fix.

---
Implemented via TamTam from issue [#101](https://github.com/3h4x/seo-tools/issues/101).