### PR TITLE
fix: Invalidate Search Console page-query caches when a site's SC identity changes

### DIFF
--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -39,6 +39,7 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-data-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-queries-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-pages-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
   });
@@ -60,6 +61,8 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:old.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:old.example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:new.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/5678');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
@@ -114,7 +117,8 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
     expect(clearCacheEntry).toHaveBeenCalledTimes(2);
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(6);
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:example.com');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(7);
     expect(clearSitemapSyncState).not.toHaveBeenCalled();
   });
 

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -2,7 +2,7 @@ import { clearCache, clearCacheEntry, clearCacheEntriesByPrefix, clearSitemapSyn
 import { getSCUrl, type Site } from './sites';
 import { normalizeGa4PropertyId } from './ga4-property';
 
-const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-'] as const;
+const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-', 'sc-page-queries-'] as const;
 const GA4_PROPERTY_CACHE_PREFIXES = ['ga4-', 'rum-cwv-'] as const;
 
 function getCacheIdentities(site: Site): {


### PR DESCRIPTION
Closes #103

Implemented issue `#103` by extending centralized Search Console cache invalidation to include the page-query namespace and updated the focused test coverage.

---
Implemented via TamTam from issue [#103](https://github.com/3h4x/seo-tools/issues/103).