### PR TITLE
fix: Invalidate PSI and CWV event caches when a site's domain or GA4 property changes

### DIFF
--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -40,8 +40,11 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-queries-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-pages-', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-mobile', 'https://example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-desktop', 'https://example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-events-', 'properties/1234');
   });
 
   it('clears Search Console and GA4 caches for previous and next identities when updating', () => {
@@ -63,10 +66,16 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:old.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:new.example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-mobile', 'https://old.example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-mobile', 'https://new.example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-desktop', 'https://old.example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-desktop', 'https://new.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/5678');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/5678');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-events-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-events-', 'properties/5678');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
   });
 
@@ -114,11 +123,14 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
     expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-mobile', 'https://example.com');
+    expect(clearCacheEntry).toHaveBeenCalledWith('psi-desktop', 'https://example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
-    expect(clearCacheEntry).toHaveBeenCalledTimes(2);
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-events-', 'properties/1234');
+    expect(clearCacheEntry).toHaveBeenCalledTimes(4);
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:example.com');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(7);
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(8);
     expect(clearSitemapSyncState).not.toHaveBeenCalled();
   });
 
@@ -129,5 +141,6 @@ describe('invalidateManagedSiteCache', () => {
 
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('ga4-', 'properties/1234');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-', 'properties/1234');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('rum-cwv-events-', 'properties/1234');
   });
 });

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -3,21 +3,31 @@ import { getSCUrl, type Site } from './sites';
 import { normalizeGa4PropertyId } from './ga4-property';
 
 const SEARCH_CONSOLE_CACHE_PREFIXES = ['sc-comparison-', 'sc-data-', 'sc-queries-', 'sc-pages-', 'sc-page-queries-'] as const;
-const GA4_PROPERTY_CACHE_PREFIXES = ['ga4-', 'rum-cwv-'] as const;
+const GA4_PROPERTY_CACHE_PREFIXES = ['ga4-', 'rum-cwv-', 'rum-cwv-events-'] as const;
+const PSI_CACHE_KEYS = ['psi-mobile', 'psi-desktop'] as const;
+
+function getDomainUrl(domain: string): string | undefined {
+  const normalizedDomain = domain.trim();
+  if (!normalizedDomain) return undefined;
+  return normalizedDomain.startsWith('http') ? normalizedDomain : `https://${normalizedDomain}`;
+}
 
 function getCacheIdentities(site: Site): {
   auditSiteId: string;
   domain: string;
   scSiteId: string;
   ga4PropertyId?: string;
+  psiUrl?: string;
 } {
   const ga4PropertyId = normalizeGa4PropertyId(site.ga4PropertyId);
+  const domain = site.domain.trim();
 
   return {
     auditSiteId: site.id,
-    domain: site.domain.trim(),
+    domain,
     scSiteId: getSCUrl(site),
     ga4PropertyId,
+    psiUrl: getDomainUrl(domain),
   };
 }
 
@@ -61,6 +71,12 @@ export function invalidateManagedSiteCache(previousSite: Site | null, nextSite: 
     clearCacheEntry('sitemap-submissions', siteId);
     for (const prefix of SEARCH_CONSOLE_CACHE_PREFIXES) {
       clearCacheEntriesByPrefix(prefix, siteId);
+    }
+  }
+
+  for (const psiUrl of unique([previous?.psiUrl, next?.psiUrl])) {
+    for (const cacheKey of PSI_CACHE_KEYS) {
+      clearCacheEntry(cacheKey, psiUrl);
     }
   }
 


### PR DESCRIPTION
Closes #100

Validated issue `#100` against current `HEAD`, created the TamTam issue branch, implemented the missing PSI and CWV event cache invalidation, and updated agent memory.

---
Implemented via TamTam from issue [#100](https://github.com/3h4x/seo-tools/issues/100).