### PR TITLE
fix: Reduce cold /performance latency by not blocking RUM-backed rows on PageSpeed fetches

### DIFF
--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,7 +1,4 @@
 import Link from 'next/link';
-import { discoverPropertyIds } from '@/lib/ga4';
-import { cachedGetRumCoreWebVitals, cachedGetCwvEventCount, type CwvMetricMap } from '@/lib/performance';
-import { cachedGetPagespeed, type PsiData } from '@/lib/pagespeed';
 import {
   CWV_METRIC_ORDER,
   PERF_VALID_DAYS,
@@ -10,6 +7,10 @@ import {
   type CwvRating,
 } from '@/lib/constants';
 import { parseAllowedIntegerParam } from '@/lib/days';
+import {
+  getPerformanceOverviewRows,
+  type PerformanceOverviewRow,
+} from '@/lib/performance-overview';
 import TimeRange from '../components/time-range';
 import CwvSetupGuide from '../components/cwv-setup-guide';
 import { CwvCell } from '../components/cwv-cell';
@@ -17,86 +18,7 @@ import { CwvMetricsCards } from '../components/cwv-metrics-cards';
 
 export const revalidate = 300;
 
-interface SiteRow {
-  id: string;
-  name: string;
-  domain: string;
-  source: 'rum' | 'rum-pending' | 'psi-field' | 'psi-lab' | 'none';
-  metrics: Partial<Record<CwvMetricName, { value: number; rating: CwvRating }>>;
-  perfScore: number | null;
-  needsKey: boolean;
-  cwvEventCount: number;
-}
-
-function fromRum(map: CwvMetricMap): SiteRow['metrics'] {
-  const out: SiteRow['metrics'] = {};
-  for (const name of CWV_METRIC_ORDER) {
-    const m = map[name];
-    if (m) out[name] = { value: m.value, rating: m.rating };
-  }
-  return out;
-}
-
-function fromPsi(psi: PsiData): { metrics: SiteRow['metrics']; source: 'psi-field' | 'psi-lab' } {
-  const out: SiteRow['metrics'] = {};
-  if (psi.field) {
-    for (const name of CWV_METRIC_ORDER) {
-      const m = psi.field[name];
-      if (m) out[name] = { value: m.value, rating: m.rating };
-    }
-    if (Object.keys(out).length > 0) return { metrics: out, source: 'psi-field' };
-  }
-  for (const name of CWV_METRIC_ORDER) {
-    const v = psi.lab[name];
-    if (typeof v === 'number') out[name] = { value: v, rating: rateCwv(name, v) };
-  }
-  return { metrics: out, source: 'psi-lab' };
-}
-
-async function getRows(days: number): Promise<SiteRow[]> {
-  const sites = await discoverPropertyIds();
-
-  return Promise.all(sites.map(async (site): Promise<SiteRow> => {
-    const propertyId = site.ga4PropertyId || '';
-    const url = site.domain.startsWith('http') ? site.domain : `https://${site.domain}`;
-
-    const [rum, eventCount, psi] = await Promise.all([
-      propertyId ? cachedGetRumCoreWebVitals(propertyId, days) : Promise.resolve(null),
-      propertyId ? cachedGetCwvEventCount(propertyId, days) : Promise.resolve(null),
-      cachedGetPagespeed(url, 'mobile'),
-    ]);
-    const cwvEventCount = eventCount ?? 0;
-
-    if (rum?.hasData) {
-      return {
-        id: site.id, name: site.name, domain: site.domain,
-        source: 'rum', metrics: fromRum(rum.overall),
-        perfScore: psi?.performanceScore ?? null,
-        needsKey: !!psi?.needsKey,
-        cwvEventCount,
-      };
-    }
-    if (psi && (psi.field || Object.keys(psi.lab).length > 0)) {
-      const { metrics, source } = fromPsi(psi);
-      return {
-        id: site.id, name: site.name, domain: site.domain,
-        source: cwvEventCount > 0 ? 'rum-pending' : source,
-        metrics, perfScore: psi.performanceScore,
-        needsKey: !!psi.needsKey,
-        cwvEventCount,
-      };
-    }
-    return {
-      id: site.id, name: site.name, domain: site.domain,
-      source: cwvEventCount > 0 ? 'rum-pending' : 'none',
-      metrics: {}, perfScore: null,
-      needsKey: !!psi?.needsKey,
-      cwvEventCount,
-    };
-  }));
-}
-
-const SOURCE_BADGE: Record<SiteRow['source'], { label: string; cls: string; tip: string }> = {
+const SOURCE_BADGE: Record<PerformanceOverviewRow['source'], { label: string; cls: string; tip: string }> = {
   'rum':         { label: 'RUM',      cls: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30', tip: 'Real-user data via GA4 core_web_vitals' },
   'rum-pending': { label: 'RUM 24h',  cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30',          tip: 'Events flowing — custom dimensions still propagating to the Data API (24–48h after registration)' },
   'psi-field':   { label: 'CrUX',     cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30',          tip: 'PageSpeed Insights field data (CrUX, p75)' },
@@ -107,7 +29,7 @@ const SOURCE_BADGE: Record<SiteRow['source'], { label: string; cls: string; tip:
 export default async function PerformancePage({ searchParams }: { searchParams: Promise<{ days?: string; guide?: string }> }) {
   const params = await searchParams;
   const days = parseAllowedIntegerParam(params.days, PERF_VALID_DAYS, 7);
-  const rows = await getRows(days);
+  const rows = await getPerformanceOverviewRows(days);
 
   const overallAgg: Record<CwvMetricName, { sum: number; count: number }> = {
     LCP:  { sum: 0, count: 0 }, INP: { sum: 0, count: 0 }, CLS: { sum: 0, count: 0 },

--- a/src/lib/__tests__/performance-overview.test.ts
+++ b/src/lib/__tests__/performance-overview.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../ga4', () => ({
+  discoverPropertyIds: vi.fn(),
+}));
+
+vi.mock('../pagespeed', () => ({
+  cachedGetPagespeed: vi.fn(),
+}));
+
+vi.mock('../performance', () => ({
+  cachedGetCwvEventCount: vi.fn(),
+  cachedGetRumCoreWebVitals: vi.fn(),
+}));
+
+import { discoverPropertyIds } from '../ga4';
+import { cachedGetPagespeed } from '../pagespeed';
+import { cachedGetCwvEventCount, cachedGetRumCoreWebVitals } from '../performance';
+import { getPerformanceOverviewRows } from '../performance-overview';
+
+const rumSite = {
+  id: 'rum-site',
+  name: 'RUM Site',
+  domain: 'rum.example.com',
+  ga4PropertyId: 'ga4-rum',
+};
+
+const psiSite = {
+  id: 'psi-site',
+  name: 'PSI Site',
+  domain: 'psi.example.com',
+  ga4PropertyId: 'ga4-psi',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(discoverPropertyIds).mockResolvedValue([rumSite, psiSite] as Awaited<ReturnType<typeof discoverPropertyIds>>);
+  vi.mocked(cachedGetCwvEventCount).mockResolvedValue(0);
+  vi.mocked(cachedGetRumCoreWebVitals).mockImplementation(async (propertyId) => {
+    if (propertyId === 'ga4-rum') {
+      return {
+        hasData: true,
+        overall: {
+          LCP: { value: 1200, rating: 'good', sampleCount: 12 },
+        },
+        byDevice: { mobile: {}, desktop: {}, tablet: {} },
+      };
+    }
+
+    return null;
+  });
+  vi.mocked(cachedGetPagespeed).mockImplementation(async (url) => ({
+    url,
+    strategy: 'mobile',
+    performanceScore: 84,
+    field: {
+      LCP: { value: 2300, rating: 'good' },
+    },
+    lab: {},
+    fetchedAt: 123,
+  }));
+});
+
+describe('getPerformanceOverviewRows', () => {
+  it('does not fetch PSI for rows that already have usable RUM data', async () => {
+    const rows = await getPerformanceOverviewRows(7);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      id: 'rum-site',
+      source: 'rum',
+      perfScore: null,
+      metrics: {
+        LCP: { value: 1200, rating: 'good' },
+      },
+    });
+    expect(vi.mocked(cachedGetPagespeed)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(cachedGetPagespeed)).toHaveBeenCalledWith('https://psi.example.com', 'mobile');
+  });
+
+  it('still fetches PSI fallback when RUM is unavailable', async () => {
+    const rows = await getPerformanceOverviewRows(28);
+
+    expect(rows[1]).toMatchObject({
+      id: 'psi-site',
+      source: 'psi-field',
+      perfScore: 84,
+      metrics: {
+        LCP: { value: 2300, rating: 'good' },
+      },
+    });
+    expect(vi.mocked(cachedGetRumCoreWebVitals)).toHaveBeenCalledWith('ga4-rum', 28);
+    expect(vi.mocked(cachedGetRumCoreWebVitals)).toHaveBeenCalledWith('ga4-psi', 28);
+  });
+});

--- a/src/lib/performance-overview.ts
+++ b/src/lib/performance-overview.ts
@@ -1,0 +1,118 @@
+import { discoverPropertyIds } from './ga4';
+import { cachedGetCwvEventCount, cachedGetRumCoreWebVitals, type CwvMetricMap } from './performance';
+import { cachedGetPagespeed, type PsiData } from './pagespeed';
+import {
+  CWV_METRIC_ORDER,
+  rateCwv,
+  type CwvMetricName,
+  type CwvRating,
+} from './constants';
+
+export interface PerformanceOverviewRow {
+  id: string;
+  name: string;
+  domain: string;
+  source: 'rum' | 'rum-pending' | 'psi-field' | 'psi-lab' | 'none';
+  metrics: Partial<Record<CwvMetricName, { value: number; rating: CwvRating }>>;
+  perfScore: number | null;
+  needsKey: boolean;
+  cwvEventCount: number;
+}
+
+function fromRum(map: CwvMetricMap): PerformanceOverviewRow['metrics'] {
+  const out: PerformanceOverviewRow['metrics'] = {};
+  for (const name of CWV_METRIC_ORDER) {
+    const metric = map[name];
+    if (metric) {
+      out[name] = { value: metric.value, rating: metric.rating };
+    }
+  }
+  return out;
+}
+
+function fromPsi(psi: PsiData): {
+  metrics: PerformanceOverviewRow['metrics'];
+  source: 'psi-field' | 'psi-lab';
+} {
+  const out: PerformanceOverviewRow['metrics'] = {};
+  if (psi.field) {
+    for (const name of CWV_METRIC_ORDER) {
+      const metric = psi.field[name];
+      if (metric) {
+        out[name] = { value: metric.value, rating: metric.rating };
+      }
+    }
+    if (Object.keys(out).length > 0) {
+      return { metrics: out, source: 'psi-field' };
+    }
+  }
+
+  for (const name of CWV_METRIC_ORDER) {
+    const value = psi.lab[name];
+    if (typeof value === 'number') {
+      out[name] = { value, rating: rateCwv(name, value) };
+    }
+  }
+
+  return { metrics: out, source: 'psi-lab' };
+}
+
+async function getPerformanceOverviewRow(
+  site: Awaited<ReturnType<typeof discoverPropertyIds>>[number],
+  days: number,
+): Promise<PerformanceOverviewRow> {
+  const propertyId = site.ga4PropertyId || '';
+  const url = site.domain.startsWith('http') ? site.domain : `https://${site.domain}`;
+
+  const [rum, eventCount] = await Promise.all([
+    propertyId ? cachedGetRumCoreWebVitals(propertyId, days) : Promise.resolve(null),
+    propertyId ? cachedGetCwvEventCount(propertyId, days) : Promise.resolve(null),
+  ]);
+
+  const cwvEventCount = eventCount ?? 0;
+
+  if (rum?.hasData) {
+    return {
+      id: site.id,
+      name: site.name,
+      domain: site.domain,
+      source: 'rum',
+      metrics: fromRum(rum.overall),
+      perfScore: null,
+      needsKey: false,
+      cwvEventCount,
+    };
+  }
+
+  const psi = await cachedGetPagespeed(url, 'mobile');
+
+  if (psi && (psi.field || Object.keys(psi.lab).length > 0)) {
+    const { metrics, source } = fromPsi(psi);
+    return {
+      id: site.id,
+      name: site.name,
+      domain: site.domain,
+      source: cwvEventCount > 0 ? 'rum-pending' : source,
+      metrics,
+      perfScore: psi.performanceScore,
+      needsKey: !!psi.needsKey,
+      cwvEventCount,
+    };
+  }
+
+  return {
+    id: site.id,
+    name: site.name,
+    domain: site.domain,
+    source: cwvEventCount > 0 ? 'rum-pending' : 'none',
+    metrics: {},
+    perfScore: null,
+    needsKey: !!psi?.needsKey,
+    cwvEventCount,
+  };
+}
+
+export async function getPerformanceOverviewRows(days: number): Promise<PerformanceOverviewRow[]> {
+  const sites = await discoverPropertyIds();
+  return Promise.all(sites.map((site) => getPerformanceOverviewRow(site, days)));
+}


### PR DESCRIPTION
Closes #99

Picked issue `#99`, validated it against current `HEAD`, created the TamTam issue branch, and implemented the overview loader change so RUM-backed performance rows stop waiting on PSI.

---
Implemented via TamTam from issue [#99](https://github.com/3h4x/seo-tools/issues/99).