### PR TITLE
chore(review): cached audit missing indexnow breaks site pages

### DIFF
--- a/src/lib/__tests__/audit-helpers.test.ts
+++ b/src/lib/__tests__/audit-helpers.test.ts
@@ -26,8 +26,10 @@ import {
   checkInternalLinks,
   extractLocsFromSitemap,
   sampleAuditPages,
+  normalizeSiteAuditResult,
   MAX_SAMPLED_PAGES,
   type FetchResult,
+  type SiteAuditResult,
 } from '../audit';
 
 function makeFetchResult(overrides: Partial<FetchResult> = {}): FetchResult {
@@ -489,5 +491,67 @@ describe('sampleAuditPages', () => {
 
   it('handles invalid URLs gracefully', () => {
     expect(() => sampleAuditPages([], ['not-a-url'], ['also-bad'], domain)).not.toThrow();
+  });
+});
+
+describe('normalizeSiteAuditResult', () => {
+  function makeLegacyAudit(overrides: Record<string, unknown> = {}): SiteAuditResult {
+    return {
+      siteId: 'test',
+      domain: 'example.com',
+      timestamp: 1000,
+      robotsTxt: { status: 'pass', label: 'robots.txt', message: 'ok', hasSitemapDirective: true },
+      sitemap: { status: 'pass', label: 'Sitemap', message: 'ok', url: 'https://example.com/sitemap.xml', urlCount: 1, isIndex: false, hasLastmod: true },
+      scSitemapFreshness: { status: 'pass', label: 'SC Sitemap', message: 'ok' },
+      indexingCoverage: { status: 'pass', label: 'Indexing', message: 'ok', indexedPages: 1 },
+      metaTags: [],
+      ogImage: { status: 'pass', label: 'OG Image', message: 'ok' },
+      ttfb: { status: 'pass', label: 'TTFB', message: 'ok', ms: 200 },
+      imageSeo: [],
+      internalLinks: [],
+      security: {
+        https: { status: 'pass', label: 'HTTPS', message: 'ok' },
+        hsts: { status: 'pass', label: 'HSTS', message: 'ok' },
+        favicon: { status: 'pass', label: 'Favicon', message: 'ok' },
+      },
+      score: { pass: 1, warn: 0, fail: 0, error: 0, total: 1 },
+      sampledPages: [],
+      ...overrides,
+    } as unknown as SiteAuditResult;
+  }
+
+  it('backfills indexNow with a warn default when absent from legacy cache', () => {
+    const audit = makeLegacyAudit();
+    const result = normalizeSiteAuditResult(audit);
+    expect(result.indexNow).toMatchObject({ status: 'warn', label: 'IndexNow' });
+    expect(result.indexNow.message).toContain('legacy cache');
+  });
+
+  it('preserves an existing indexNow check unchanged', () => {
+    const indexNow = { status: 'pass' as const, label: 'IndexNow', message: 'Key verified' };
+    const audit = makeLegacyAudit({ indexNow });
+    const result = normalizeSiteAuditResult(audit);
+    expect(result.indexNow).toBe(indexNow);
+  });
+
+  it('backfills urlInspection with empty array when absent', () => {
+    const audit = makeLegacyAudit();
+    const result = normalizeSiteAuditResult(audit);
+    expect(result.urlInspection).toEqual([]);
+  });
+
+  it('backfills redirectChains with empty array when absent', () => {
+    const audit = makeLegacyAudit();
+    const result = normalizeSiteAuditResult(audit);
+    expect(result.redirectChains).toEqual([]);
+  });
+
+  it('normalizes a fully legacy audit (no indexNow, no urlInspection) without throwing', () => {
+    const audit = makeLegacyAudit();
+    expect(() => normalizeSiteAuditResult(audit)).not.toThrow();
+    const result = normalizeSiteAuditResult(audit);
+    expect(result.indexNow.status).toBe('warn');
+    expect(result.urlInspection).toEqual([]);
+    expect(result.redirectChains).toEqual([]);
   });
 });

--- a/src/lib/__tests__/site-cache.test.ts
+++ b/src/lib/__tests__/site-cache.test.ts
@@ -41,6 +41,7 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntry).toHaveBeenCalledWith('audit', 'site1');
     expect(clearCacheEntriesBySiteIdPrefix).toHaveBeenCalledWith('url-inspection', 'site1:');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('opportunities-', 'site1');
     expect(clearSitemapSyncState).toHaveBeenCalledWith('site1');
     expect(clearCacheEntry).toHaveBeenCalledWith('sitemap-submissions', 'sc-domain:example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:example.com');
@@ -71,6 +72,7 @@ describe('invalidateManagedSiteCache', () => {
 
     expect(clearCache).toHaveBeenCalledWith('cross-links-matrix');
     expect(clearCacheEntriesBySiteIdPrefix).toHaveBeenCalledWith('url-inspection', 'site1:');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('opportunities-', 'site1');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:old.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-comparison-', 'sc-domain:new.example.com');
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:old.example.com');
@@ -144,7 +146,8 @@ describe('invalidateManagedSiteCache', () => {
     expect(clearCacheEntry).toHaveBeenCalledTimes(4);
     expect(clearCacheEntriesBySiteIdPrefix).toHaveBeenCalledTimes(1);
     expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('sc-page-queries-', 'sc-domain:example.com');
-    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(8);
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledWith('opportunities-', 'site1');
+    expect(clearCacheEntriesByPrefix).toHaveBeenCalledTimes(9);
     expect(clearSitemapSyncState).not.toHaveBeenCalled();
   });
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -173,9 +173,16 @@ export interface SiteAuditResult {
   sampledPages: string[];
 }
 
+const LEGACY_INDEXNOW_DEFAULT: CheckResult = {
+  status: 'warn',
+  label: 'IndexNow',
+  message: 'Not audited (legacy cache — refresh to update)',
+};
+
 export function normalizeSiteAuditResult(audit: SiteAuditResult): SiteAuditResult {
   return {
     ...audit,
+    indexNow: audit.indexNow ?? LEGACY_INDEXNOW_DEFAULT,
     urlInspection: audit.urlInspection ?? [],
     redirectChains: audit.redirectChains ?? [],
     internalLinks: (audit.internalLinks ?? []).map((link) => ({

--- a/src/lib/site-cache.ts
+++ b/src/lib/site-cache.ts
@@ -64,6 +64,7 @@ export function invalidateManagedSiteCache(previousSite: Site | null, nextSite: 
   for (const siteId of auditSiteIds) {
     clearCacheEntry('audit', siteId);
     clearCacheEntriesBySiteIdPrefix('url-inspection', `${siteId}:`);
+    clearCacheEntriesByPrefix('opportunities-', siteId);
   }
 
   if (shouldClearSitemapSyncState(previous, next)) {


### PR DESCRIPTION
Closes #111

Implemented via TamTam from issue [#111](https://github.com/3h4x/seo-tools/issues/111).