### PR TITLE
fix: Accept and normalize bare GA4 property IDs in managed-site config

### DIFF
--- a/app/api/daily/route.ts
+++ b/app/api/daily/route.ts
@@ -3,6 +3,10 @@ import { getScDaily, getGa4Daily } from '@/lib/db';
 import { getManagedSites } from '@/lib/sites';
 import { CHART_COLORS } from '@/lib/constants';
 
+function formatDateOnly(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
 export async function GET(req: NextRequest) {
   const parsedDays = parseInt(req.nextUrl.searchParams.get('days') || '30');
   const days = Number.isFinite(parsedDays) ? Math.min(365, Math.max(1, parsedDays)) : 30;
@@ -10,7 +14,7 @@ export async function GET(req: NextRequest) {
   // Calculate the cutoff date
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - days);
-  const cutoffStr = cutoff.toISOString().split('T')[0];
+  const cutoffStr = formatDateOnly(cutoff);
 
   const result: Record<string, Record<string, { users: number; views: number; clicks: number; impressions: number }>> = {};
 

--- a/src/lib/__tests__/api-daily.test.ts
+++ b/src/lib/__tests__/api-daily.test.ts
@@ -29,6 +29,7 @@ const SITE = { id: 'site1', name: 'Site One', domain: 'site1.com', testPages: []
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useRealTimers();
   vi.mocked(getManagedSites).mockResolvedValue([SITE] as never);
   vi.mocked(getScDaily).mockReturnValue([]);
   vi.mocked(getGa4Daily).mockReturnValue([]);
@@ -97,6 +98,31 @@ describe('GET /api/daily', () => {
 
     expect(body.data[staleDate]).toBeUndefined();
     expect(body.data[recentDate]?.site1).toMatchObject({
+      clicks: 5,
+      impressions: 50,
+      users: 20,
+      views: 80,
+    });
+  });
+
+  it('uses local calendar dates for the cutoff across spring DST boundaries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-30T00:30:00+02:00'));
+
+    vi.mocked(getScDaily).mockReturnValue([
+      { date: '2026-03-28', clicks: 99, impressions: 999 },
+      { date: '2026-03-29', clicks: 5, impressions: 50 },
+    ] as never);
+    vi.mocked(getGa4Daily).mockReturnValue([
+      { date: '2026-03-28', users: 77, views: 777 },
+      { date: '2026-03-29', users: 20, views: 80 },
+    ] as never);
+
+    const res = await GET(getReq(1));
+    const body = await res.json();
+
+    expect(body.data['2026-03-28']).toBeUndefined();
+    expect(body.data['2026-03-29']?.site1).toMatchObject({
       clicks: 5,
       impressions: 50,
       users: 20,


### PR DESCRIPTION
Closes #113

Implemented via TamTam from issue [#113](https://github.com/3h4x/seo-tools/issues/113).